### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ def test_models():
 
 ### Magic fixture fence
 
-Warn when implicit fixtures are used in specified modules:
+Warn when magic fixtures are used in specified modules:
 
 ```python
 from unmagic import fence

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ def test_query(db):
 
 **pytest-unmagic** (explicit):
 
+fixtures.py
 ```python
-# fixtures.py
 from unmagic import fixture
 
 @fixture

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ def test_greeting():
 
 - **Fixture scopes:** `function`, `class`, `module`, `package`, `session`
 
-- **Magic fence:** Warn when implicit fixtures are used in designated
+- **Magic fence:** Warn when magic fixtures are used in designated
   modules
 
 ## Core Concepts

--- a/README.md
+++ b/README.md
@@ -2,217 +2,217 @@
 
 Pytest fixtures with conventional import semantics.
 
+pytest-unmagic removes the "magic" from pytest fixtures. Instead of
+relying on argument-name matching, fixtures are explicitly imported and
+applied using standard Python conventions. This gives you IDE
+navigation, clear dependency chains, and `unittest.TestCase` support.
+
+## Quick Comparison
+
+**Standard pytest** (implicit):
+
+```python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def db():
+    return create_database()
+
+# test_app.py -- where does `db` come from?
+def test_query(db):
+    assert db.query("SELECT 1")
+```
+
+**pytest-unmagic** (explicit):
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+
+# test_app.py -- clear import, visible dependency
+from fixtures import db
+
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
 ## Installation
 
 ```sh
 pip install pytest-unmagic
 ```
 
-## Usage
+## Quick Start
 
-Define fixtures with the `unmagic.fixture` decorator, and apply them to other
-fixtures or test functions with `unmagic.use`.
+Define a fixture with `@fixture`, apply it with `@use` or call it to get
+its value:
 
-```py
+```python
 from unmagic import fixture, use
 
-traces = []
+@fixture
+def greeting():
+    yield "hello"
+
+@use(greeting)
+def test_greeting():
+    value = greeting()
+    assert value == "hello"
+```
+
+## Key Features
+
+- **Explicit imports:** Fixtures are regular Python objects, imported
+  where used
+
+- **IDE support:** go-to-definition, find-usages, and refactoring work
+  out of the box
+
+- **`unittest.TestCase` support:** Apply fixtures to TestCase classes
+  with `@use`
+
+- **Gradual adoption:** Mix with standard pytest fixtures, migrate
+  incrementally
+
+- **Fixture scopes:** `function`, `class`, `module`, `package`, `session`
+
+- **Magic fence:** Warn when implicit fixtures are used in designated
+  modules
+
+## Core Concepts
+
+### Define a fixture
+
+```python
+from unmagic import fixture
 
 @fixture
-def tracer():
-    assert not traces, f"unexpected traces before setup: {traces}"
-    yield
-    traces.clear()
-
-@use(tracer)
-def test_append():
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+def db():
+    connection = create_connection()
+    yield connection
+    connection.close()
 ```
 
-A fixture must yield exactly once. The `@use` decorator causes the fixture to be
-set up and registered for tear down, but does not pass the yielded value to the
-decorated function. This is appropriate for fixtures that have side effects.
+The fixture must yield exactly once. Code before `yield` is setup; code
+after is teardown.
 
-The location where a fixture is defined has no affect on where it can be used.
-Any code that can import it can use it as long as it is executed in the context
-of running tests and does not violate scope restrictions.
+### Apply a fixture with `@use`
 
-### @use shorthand
+```python
+from unmagic import use
 
-If a single fixture is being applied to another fixture or test it may be
-applied directly as a decorator without `@use()`. The test in the example above
-could have been written as
-
-```py
-@tracer
-def test_append():
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+@use(db)
+def test_insert():
+    database = db()
+    database.insert({"key": "value"})
 ```
 
-### Applying fixtures to test classes
+`@use` sets up the fixture and registers it for teardown. Call the fixture to retrieve its value.
 
-The `@use` decorator can be used on test classes, which applies the fixture(s)
-to every test in the class.
+### `@use` shorthand
 
-```py
-@use(tracer)
-class TestClass:
-    def test_galaxy(self):
-        traces.append("Is anybody out there?")
-```
+A single fixture can be applied directly as a decorator:
 
-#### Unmagic fixtures on `unittest.TestCase` tests
-
-Unlike standard pytest fixtures, unmagic fixtures can be applied directly to
-`unittest.TestCase` tests.
-
-### Call a fixture to retrieve its value
-
-The value of a fixture can be retrieved within a test function or other fixture
-by calling the fixture. This is similar to `request.getfixturevalue()`.
-
-```py
-@fixture
-def tracer():
-    assert not traces, f"unexpected traces before setup: {traces}"
-    yield traces
-    traces.clear()
-
-def test_append():
-    traces = tracer()
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+```python
+@db
+def test_insert():
+    database = db()
+    ...
 ```
 
 ### Fixture scope
 
-Fixtures may declare a `scope` of `'function'` (the default), `'class'`,
-`'module'`, `'package'`, or `'session'`. A fixture will be torn down after all
-tests in its scope have run if any in-scope tests used the fixture.
-
-```py
-@fixture(scope="class")
-def tracer():
-    traces = []
-    yield traces
-    assert traces, "expected at least one trace"
+```python
+@fixture(scope="module")
+def shared_db():
+    yield create_database()
 ```
+
+### Apply fixtures to classes
+
+```python
+@use(db)
+class TestQueries:
+    def test_select(self):
+        database = db()
+        assert database.query("SELECT 1")
+```
+
+Works with `unittest.TestCase` too, unlike standard pytest fixtures.
 
 ### Autouse fixtures
 
-Fixtures may be applied to tests automatically with `@fixture(autouse=...)`. The
-value of the `autouse` parameter may be one of
-
-- A test module or package path (usually `__file__`) to apply the fixture to all
-  tests within the module or package.
-- `True`: apply the fixture to all tests in the session.
-
-A single fixture may be registered for autouse in multiple modules and packages
-with ``unmagic.autouse``.
-
-```py
-# tests/fixtures.py
-from unmagic import fixture
-
-@fixture
-def a_fixture():
-    ...
-
-
-# tests/test_this.py
-from unmagic import autouse
-from .fixtures import a_fixture
-
-autouse(a_fixture, __file__)
-
-...
-
-
-# tests/test_that.py
-from unmagic import autouse
-from .fixtures import a_fixture
-
-autouse(a_fixture, __file__)
-
-...
+```python
+@fixture(autouse=__file__)
+def setup_env():
+    os.environ["MODE"] = "test"
+    yield
+    del os.environ["MODE"]
 ```
 
-### Magic fixture fence
+Or register autouse from another module:
 
-It is possible to errect a fence around tests in a particular module or package
-to ensure that magic fixtures are not used in that namespace except with the
-`@use(...)` decorator.
+```python
+from unmagic import autouse
+from .fixtures import setup_env
 
-```py
-from unmagic import fence
-
-fence.install(['mypackage.tests'])
+autouse(setup_env, __file__)
 ```
 
-This will cause warnings to be emitted for magic fixture usages within
-`mypackage.tests`.
+### Access pytest fixtures
 
-
-### Accessing the pytest request object
-
-The `unmagic.get_request()` function provides access to the test request object.
-Among other things, it can be used to retrieve fixtures defined with
-`@pytest.fixture`.
-
-```py
+```python
 from unmagic import get_request
 
 def test_output():
     capsys = get_request().getfixturevalue("capsys")
     print("hello")
-    captured = capsys.readouterr()
-    assert captured.out == "hello\n"
+    assert capsys.readouterr().out == "hello\n"
 ```
 
-### `@use` pytest fixtures
-
-Fixtures defined with `@pytest.fixture` can be applied to a test or other
-fixture by passing the fixture name to `@use`. None of the built-in fixtures
-provided by pytest make sense to use this way, but it is a useful technique for
-fixtures that have side effects, such as pytest-django's `db` fixture.
-
-```py
-from unmagic import use
-
-@use("db")
-def test_database():
-    ...
-```
-
-### Chaining fixtures
-
-Fixtures that use other fixtures should be decorated with `@use`, so
-that fixture dependencies are chained.
+Or apply pytest fixtures by name:
 
 ```python
-@use("db")
-def parent_fixture():
-    daedalus = Person.objects.create(name='Daedalus')
-    yield daedalus
-    daedalus.delete()
+from unmagic import use
 
-@use(parent_fixture)
-@fixture
-def child_fixture():
-    daedalus = parent_fixture()
-    icarus = Person.objects.create(name='Icarus', father=daedalus)
-    yield
-
-@use(child_fixture)
-def test_flight():
-    flyers = Person.objects.all()
+@use("db")  # pytest-django's db fixture
+def test_models():
     ...
 ```
 
+### Magic fixture fence
 
-## Running the `unmagic` test suite
+Warn when implicit fixtures are used in specified modules:
+
+```python
+from unmagic import fence
+
+fence.install(["mypackage.tests"])
+```
+
+## Documentation
+
+| Document                                   | Description                           |
+|--------------------------------------------|---------------------------------------|
+| [Tutorial](docs/tutorial.md)               | Hands-on introduction (~30 min)       |
+| [Migration Guide](docs/migration-guide.md) | Convert from standard pytest fixtures |
+| [API Reference](docs/api-reference.md)     | Complete technical reference          |
+| [How-to Guides](docs/howto/index.md)       | Task-focused solutions                |
+| [Concepts](docs/concepts.md)               | Philosophy and design principles      |
+| [FAQ](docs/faq.md)                         | Common questions and troubleshooting  |
+
+## Compatibility
+
+- **Python:** 3.9+
+- **pytest:** 8.1+
+
+## Running the Test Suite
 
 ```sh
 cd path/to/pytest-unmagic
@@ -220,13 +220,12 @@ pip install -e .
 pytest
 ```
 
+## Publishing
 
-## Publishing a new verison to PyPI
+Push a tag matching `vX.Y.Z` (where X.Y.Z matches the version in
+[`__init__.py`](src/unmagic/__init__.py)) to publish to PyPI.
 
-Push a new tag to Github using the format vX.Y.Z where X.Y.Z matches the version
-in [`__init__.py`](src/unmagic/__init__.py).
-
-A new version is published to https://test.pypi.org/p/pytest-unmagic on every
+A test release is published to https://test.pypi.org/p/pytest-unmagic on every
 push to the *main* branch.
 
-Publishing is automated with [Github Actions](.github/workflows/pypi.yml).
+Publishing is automated with [GitHub Actions](.github/workflows/pypi.yml).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,386 @@
+# API Reference
+
+**Type:** Information-oriented
+**Module:** `unmagic`
+**Version:** 1.0.1
+
+Complete technical reference for all public APIs in pytest-unmagic.
+
+## Module: `unmagic`
+
+### `fixture(func=None, /, scope="function", autouse=False)`
+
+Define an unmagic fixture.
+
+**Parameters:**
+
+| Parameter | Type              | Default      | Description                                                                                                                                      |
+|-----------|-------------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `func`    | callable or `str` | `None`       | A generator function, context manager, or pytest fixture name (string). When `None`, returns a decorator.                                        |
+| `scope`   | `str`             | `"function"` | Fixture lifecycle scope. One of: `"function"`, `"class"`, `"module"`, `"package"`, `"session"`.                                                  |
+| `autouse` | `bool` or `str`   | `False`      | Automatically apply the fixture. `True` applies to all tests. A file path (typically `__file__`) applies to tests within that module or package. |
+
+**Returns:** `UnmagicFixture` instance.
+
+**Usage as decorator:**
+
+```python
+from unmagic import fixture
+
+@fixture
+def my_fixture():
+    # setup
+    value = create_resource()
+    yield value
+    # teardown
+    cleanup_resource(value)
+```
+
+**Usage with scope:**
+
+```python
+@fixture(scope="module")
+def shared_resource():
+    yield create_expensive_resource()
+```
+
+**Usage with autouse:**
+
+```python
+# Apply to all tests in this module
+@fixture(autouse=__file__)
+def setup_env():
+    yield
+
+# Apply to all tests in the session
+@fixture(autouse=True)
+def global_setup():
+    yield
+```
+
+**Usage with a context manager:**
+
+```python
+from unittest.mock import patch
+
+fixture(patch("mymodule.func", return_value=42), autouse=__file__)
+```
+
+**Usage with a string (pytest fixture name):**
+
+```python
+db = fixture("db")  # Wraps pytest-django's db fixture
+```
+
+**Requirements:**
+
+- Generator functions must yield exactly once
+- The yielded value becomes the fixture's return value when called
+- Code after `yield` runs during teardown
+- String arguments cannot use `autouse` or non-default `scope`
+
+---
+
+### `use(*fixtures)`
+
+Apply one or more fixtures to a test function, test class, or another fixture.
+
+**Parameters:**
+
+| Parameter   | Type                                        | Description                                                                     |
+|-------------|---------------------------------------------|---------------------------------------------------------------------------------|
+| `*fixtures` | `UnmagicFixture`, context manager, or `str` | One or more fixtures to apply. Strings are interpreted as pytest fixture names. |
+
+**Returns:** Decorator function.
+
+**Raises:** `TypeError` if no fixtures are provided.
+
+**Apply to a test function:**
+
+```python
+from unmagic import fixture, use
+
+@fixture
+def db():
+    yield create_db()
+
+@use(db)
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
+**Apply to a test class:**
+
+```python
+@use(db)
+class TestDatabase:
+    def test_insert(self):
+        database = db()
+        database.insert({"key": "value"})
+
+    def test_query(self):
+        database = db()
+        assert database.query("SELECT 1")
+```
+
+**Apply multiple fixtures:**
+
+```python
+@use(db, cache, auth)
+def test_full_stack():
+    ...
+```
+
+**Apply a pytest fixture by name:**
+
+```python
+@use("db")
+def test_django():
+    ...
+```
+
+**Chain fixture dependencies:**
+
+```python
+@use(db)
+@fixture
+def populated_db():
+    database = db()
+    database.insert(seed_data)
+    yield database
+```
+
+> [!NOTE]
+> When applying `@use` to a fixture, place `@use` *above* `@fixture`:
+
+```python
+# Correct order:
+@use(dependency)
+@fixture
+def my_fixture():
+    yield
+
+# Wrong: @use cannot wrap an autouse fixture:
+@use(dependency)
+@fixture(autouse=__file__)  # TypeError
+def my_fixture():
+    yield
+
+# Correct: apply @use before @fixture(autouse=...):
+@fixture(autouse=__file__)
+@use(dependency)
+def my_fixture():
+    yield
+```
+
+---
+
+### `get_request()`
+
+Get the active pytest request object.
+
+**Returns:** `pytest.FixtureRequest`
+
+**Raises:** `ValueError` if called outside of a test or fixture context (i.e., there is no active request).
+
+**Access pytest fixtures:**
+
+```python
+from unmagic import get_request
+
+def test_output():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+```
+
+**Access test metadata:**
+
+```python
+def test_node_info():
+    request = get_request()
+    print(request.node.name)      # test name
+    print(request.node.nodeid)    # full test ID
+```
+
+---
+
+### `autouse(fixture, where)`
+
+Register a fixture for automatic use within a scope.
+
+This is useful when the fixture is defined in a shared module and you want to apply it to specific test modules or packages without using `@fixture(autouse=...)`.
+
+**Parameters:**
+
+| Parameter | Type             | Description                                                                             |
+|-----------|------------------|-----------------------------------------------------------------------------------------|
+| `fixture` | `UnmagicFixture` | An unmagic fixture to register.                                                         |
+| `where`   | `str` or `True`  | `__file__` to apply within the current module or package. `True` to apply to all tests. |
+
+**Returns:** None.
+
+**Apply to a specific module:**
+
+```python
+# tests/fixtures.py
+from unmagic import fixture
+
+@fixture
+def setup_env():
+    yield
+
+# tests/test_this.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+```
+
+**Apply to a package (in `__init__.py`):**
+
+```python
+# tests/__init__.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+```
+
+When `__file__` is in an `__init__.py`, the fixture applies to the entire package.
+
+**Apply globally:**
+
+```python
+autouse(setup_env, True)
+```
+
+> [!WARNING]
+> Calling `autouse()` during test execution (after collection) will emit
+> a `UserWarning` since relevant tests may have already run.
+
+---
+
+## Module: `unmagic.fence`
+
+### `fence.install(names=(), reset=False)`
+
+Install a fence that warns when magic fixtures are used within the named
+modules or packages.
+
+**Parameters:**
+
+| Parameter | Type              | Default | Description                                                       |
+|-----------|-------------------|---------|-------------------------------------------------------------------|
+| `names`   | sequence of `str` | `()`    | Module or package names to fence.                                 |
+| `reset`   | `bool`            | `False` | If `True`, replace all existing fences instead of adding to them. |
+
+**Returns:** Context manager. The fence is removed when the context exits.
+
+**Raises:** `ValueError` if `names` is a string instead of a sequence.
+
+**Install globally (e.g., in `conftest.py`):**
+
+```python
+# conftest.py
+from unmagic import fence
+
+fence.install(["mypackage.tests"])
+```
+
+**Install as a context manager:**
+
+```python
+from unmagic import fence
+
+with fence.install(["mypackage.tests"]):
+    # fence is active
+    ...
+# fence is removed
+```
+
+**Install for a pytest session with a fixture:**
+
+```python
+from pytest import fixture
+from unmagic import fence
+
+@fixture(scope="session", autouse=True)
+def enforce_unmagic():
+    with fence.install(["tests"]):
+        yield
+```
+
+**Nested fences:**
+
+Fences stack. Each `fence.install()` adds to the set of fenced modules.
+Inner fences are removed when their context exits, but outer fences
+remain.
+
+---
+
+### `fence.is_fenced(func)`
+
+Check whether a function is within a fenced module.
+
+**Parameters:**
+
+| Parameter | Type     | Description                                                          |
+|-----------|----------|----------------------------------------------------------------------|
+| `func`    | callable | A function to check. Uses `func.__module__` to determine membership. |
+
+**Returns:** `bool` -- `True` if the function's module is within a fenced namespace.
+
+```python
+from unmagic import fence
+
+with fence.install(["mypackage.tests"]):
+    from mypackage.tests.test_example import some_func
+    assert fence.is_fenced(some_func)
+```
+
+---
+
+## Fixture Calling Convention
+
+An `UnmagicFixture` instance is callable with two behaviors:
+
+- **`fixture()`** (no arguments): Retrieves the fixture's yielded value.
+  The fixture is set up if it hasn't been already. Must be called
+  within a test or fixture context.
+
+- **`fixture(func)`** (one argument): Applies the fixture to `func`,
+  equivalent to `@use(fixture)`. This is the `@use` shorthand.
+
+```python
+@fixture
+def db():
+    yield create_database()
+
+# Shorthand: apply as decorator
+@db
+def test_something():
+    database = db()  # retrieve value
+    ...
+```
+
+---
+
+## Compatibility
+
+|                       | Supported                   |
+|-----------------------|-----------------------------|
+| **Python**            | 3.9, 3.10, 3.11, 3.12, 3.13 |
+| **pytest**            | 8.1, 8.2, 8.3, 8.4          |
+| **unittest.TestCase** | Yes (via `@use` on class)   |
+
+---
+
+## See Also
+
+- [Tutorial](tutorial.md): Learn through examples
+- [Migration Guide](migration-guide.md): Convert from standard pytest
+- [How-to Guides](howto/index.md): Task-focused solutions
+- [FAQ](faq.md): Common questions and errors

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -197,7 +197,7 @@ fixtures (like `db` from pytest-django) via `@use("name")` or
 
 ## The Fence
 
-The fence feature supports gradual migration by warning about implicit
+The fence feature supports gradual migration by warning about magic
 fixture usage:
 
 ```python

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,216 @@
+# Concepts
+
+**Type:** Understanding-oriented
+**Audience:** Developers who want to understand why pytest-unmagic exists
+**Next:** [Tutorial](tutorial.md) or [API Reference](api-reference.md)
+
+## The Problem: pytest's "Magic"
+
+pytest fixtures use argument-name matching to inject dependencies into
+test functions. When you write `def test_query(db):`, pytest searches
+its fixture registry for a fixture named `db` and passes its value as
+an argument.
+
+This is "magic" in the sense that the connection between the test and
+the fixture is implicit:
+
+```python
+def test_query(db):
+    assert db.query("SELECT 1")
+```
+
+Where does `db` come from? To answer that, you need to know:
+
+1. Which `conftest.py` files are in scope
+2. Which plugins are active
+3. Whether any fixture with that name exists in the current file
+4. The fixture discovery and shadowing rules
+
+None of this is visible in the code itself.
+
+## When Magic Breaks Down
+
+### Discovery confusion
+
+Fixtures can be defined in any `conftest.py` in the directory tree. In
+large projects, it becomes difficult to know which fixture you're
+actually using, especially when fixtures shadow each other across
+directories.
+
+### Name collisions
+
+Two fixtures with the same name in different `conftest.py` files shadow
+each other based on directory depth. This is a common source of subtle
+bugs.
+
+### IDE blindness
+
+Standard tooling can't follow fixture resolution. "Go to definition"
+doesn't work for `db` in `def test_query(db):` because the connection
+is made at runtime by pytest, not by Python's import system.
+
+### Implicit dependencies
+
+There's no way to see what a test depends on without understanding
+pytest's discovery mechanism. The test signature tells you the names,
+but not where they come from.
+
+### unittest.TestCase incompatibility
+
+Standard pytest fixtures cannot be injected into `unittest.TestCase`
+methods at all. This forces a choice between fixture reuse and the
+TestCase base class.
+
+## The Solution: Explicit is Better Than Implicit
+
+pytest-unmagic applies the Python principle "Explicit is better than
+implicit" (PEP 20) to fixtures:
+
+```python
+from fixtures import db  # explicit import
+
+def test_query():
+    database = db()      # explicit call
+    assert database.query("SELECT 1")
+```
+
+Every fixture dependency is visible as an import at the top of the file.
+Your IDE can navigate to it, refactoring tools can rename it, and new
+developers can understand the test without knowing pytest internals.
+
+## Design Principles
+
+### Conventional Python semantics
+
+Fixtures are Python objects. You import them, you call them, you pass
+them around. No special discovery mechanism.
+
+### Visible dependencies
+
+Every fixture used by a test is either imported at the top of the file
+or applied with a visible `@use` decorator. There are no hidden
+dependencies.
+
+### Gradual adoption
+
+pytest-unmagic coexists with standard pytest fixtures. You can migrate
+one file at a time, or use both styles in the same project
+indefinitely.
+
+### No worse than pytest
+
+Anything you can do with standard pytest fixtures, you can do with
+unmagic fixtures. Scopes, teardown, parametrize, and plugin fixtures
+all work.
+
+## How It Works
+
+When you decorate a function with `@fixture`, pytest-unmagic creates an
+`UnmagicFixture` object. This object:
+
+1. **Registers** the fixture with pytest's fixture manager when a test
+   that uses it is collected
+
+2. **Sets up** the fixture (runs code before `yield`) when the test or a
+   `@use` decorator triggers it
+
+3. **Returns** the yielded value when the fixture is called
+
+4. **Tears down** the fixture (runs code after `yield`) when the scope
+   exits
+
+The `@use` decorator marks a test or fixture as depending on one or more
+unmagic fixtures, ensuring they're set up before the test runs.
+
+Calling `fixture()` inside a test doesn't re-run the fixture -- it
+retrieves the value that was yielded during setup.
+
+## Comparison With Alternatives
+
+### vs. Standard pytest fixtures
+
+| Aspect           | Standard pytest        | pytest-unmagic          |
+|------------------|------------------------|-------------------------|
+| Discovery        | Name-matching magic    | Python imports          |
+| IDE support      | Limited                | Full                    |
+| TestCase support | No                     | Yes                     |
+| Learning curve   | Higher (fixture rules) | Lower (standard Python) |
+| Adoption         | All or nothing         | Gradual                 |
+
+### vs. unittest
+
+| Aspect          | unittest               | pytest-unmagic                            |
+|-----------------|------------------------|-------------------------------------------|
+| Setup/teardown  | setUp/tearDown methods | `@fixture` with yield                     |
+| Shared fixtures | Class inheritance      | Import and compose                        |
+| Scopes          | Class only             | function, class, module, package, session |
+| Parametrize     | subTest                | `@pytest.mark.parametrize`                |
+
+### vs. Dependency injection frameworks
+
+pytest-unmagic is not a DI framework. It's a thin layer that makes
+pytest fixtures work with Python's import system. There's no container,
+no resolution graph, no configuration. Fixtures are just decorated
+generator functions.
+
+## Common Misconceptions
+
+### "It's just more boilerplate"
+
+The extra `@use(fixture)` decorator and `fixture()` call add two lines
+per fixture per test. In exchange, you get explicit imports, IDE
+navigation, and `TestCase` support. The trade-off is strongly in favor
+of explicitness for projects with more than a handful of fixtures.
+
+### "I'll lose pytest features"
+
+No. Scopes, teardown, parametrize, and plugin fixtures all work. You can
+also access any standard pytest fixture via
+`get_request().getfixturevalue("name")` or `@use("name")`.
+
+### "It's hard to adopt"
+
+pytest-unmagic supports gradual adoption. You can convert one fixture at
+a time and mix both styles in the same project. The
+[migration guide](migration-guide.md) covers this in detail.
+
+## When to Use pytest-unmagic
+
+**Good fit:**
+
+- Projects with many fixtures across multiple files
+- Teams where developers are confused by fixture discovery
+- Codebases that use `unittest.TestCase`
+- Projects where IDE support is important
+
+**Less ideal:**
+
+- Very small projects with a few obvious fixtures
+- Projects where everyone on the team is comfortable with pytest fixture
+  magic
+
+**Mixed approach:**
+
+Use unmagic for your own fixtures and access third-party plugin
+fixtures (like `db` from pytest-django) via `@use("name")` or
+`get_request().getfixturevalue("name")`.
+
+## The Fence
+
+The fence feature supports gradual migration by warning about implicit
+fixture usage:
+
+```python
+fence.install(["mypackage.tests"])
+```
+
+This doesn't break anything -- tests still pass. But you get warnings
+showing which tests and fixtures still rely on name-matching magic. As
+you migrate, the warnings decrease until you can remove the fence.
+
+## See Also
+
+- [Tutorial](tutorial.md): Learn through hands-on practice
+- [Migration Guide](migration-guide.md): Convert from standard pytest
+- [API Reference](api-reference.md): Complete API specification
+- [FAQ](faq.md): Common questions

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,306 @@
+# FAQ
+
+**Type:** Troubleshooting and common questions
+
+## Getting Started
+
+### Should I use pytest-unmagic?
+
+Use pytest-unmagic if you want:
+
+- Explicit fixture dependencies via standard Python imports
+- IDE navigation (go-to-definition, find-usages) for fixtures
+- Fixtures that work with `unittest.TestCase`
+- To eliminate name-collision issues with pytest's fixture discovery
+
+If you're happy with standard pytest fixtures and don't experience these
+pain points, you don't need to switch.
+
+### Can I mix unmagic and standard pytest fixtures?
+
+Yes. pytest-unmagic is designed for gradual adoption. You can use both
+in the same project, and even in the same test file. Use
+`get_request().getfixturevalue("name")` or `@use("name")` to access
+standard pytest fixtures from unmagic code.
+
+### Do I need to migrate all at once?
+
+No. You can migrate one file or one fixture at a time. The
+[Migration Guide](migration-guide.md) covers gradual adoption strategies.
+
+## Common Errors
+
+### "There is no active request"
+
+**Error:**
+
+```
+ValueError: There is no active request
+```
+
+**Cause:** `get_request()` or a fixture call was made outside of a test
+or fixture context.
+
+**Solution:** Ensure you only call `get_request()` or call fixtures
+inside a test function or another fixture:
+
+```python
+# Wrong: called at module level
+value = my_fixture()  # ValueError
+
+# Correct: called inside a test
+def test_something():
+    value = my_fixture()
+```
+
+### "There is no active pytest session"
+
+**Error:**
+
+```
+ValueError: There is no active pytest session
+```
+
+**Cause:** Attempted to access the active session before pytest has
+started or after it has finished.
+
+**Solution:** This typically happens in plugin code that runs too early.
+Ensure your code runs during or after `pytest_sessionstart`.
+
+### "fixture setup failed"
+
+**Error:**
+
+```
+FAILED - fixture setup for 'test_name' failed: ExceptionType: message
+```
+
+**Cause:** An exception occurred during fixture setup (before `yield`).
+
+**Solution:** Check the fixture's setup code. The error message includes
+the exception type and message. Common causes:
+
+- Missing resource (database, file, service)
+- Incorrect fixture ordering (dependency not set up yet)
+- Code error in the fixture
+
+### "Cannot apply @use to autouse fixture"
+
+**Error:**
+
+```
+TypeError: Cannot apply @use to autouse fixture ...
+```
+
+**Cause:** Applied `@use` on top of `@fixture(autouse=...)`.
+
+**Solution:** Reverse the decorator order:
+
+```python
+# Wrong:
+@use(dependency)
+@fixture(autouse=__file__)
+def my_fixture():
+    yield
+
+# Correct:
+@fixture(autouse=__file__)
+@use(dependency)
+def my_fixture():
+    yield
+```
+
+### "is not a fixture"
+
+**Error:**
+
+```
+TypeError: <object> is not a fixture. Hint: expected generator function, context manager, or pytest.fixture name.
+```
+
+**Cause:** Passed something to `@use()` or `fixture()` that isn't a
+valid fixture type.
+
+**Solution:** Ensure you pass one of:
+
+- A generator function decorated with `@fixture`
+- A context manager
+- A string naming a pytest fixture
+
+```python
+# Wrong:
+@use(42)
+def test_something():
+    ...
+
+# Correct:
+@use(my_fixture)
+def test_something():
+    ...
+```
+
+### "names should be a sequence of strings, not a string"
+
+**Error:**
+
+```
+ValueError: names should be a sequence of strings, not a string
+```
+
+**Cause:** Passed a string instead of a list to `fence.install()`.
+
+**Solution:**
+
+```python
+# Wrong:
+fence.install("mypackage.tests")
+
+# Correct:
+fence.install(["mypackage.tests"])
+```
+
+## Usage Questions
+
+### How do I get the value from a fixture?
+
+Call the fixture inside your test:
+
+```python
+@fixture
+def db():
+    yield create_database()
+
+def test_query():
+    database = db()  # returns the yielded value
+    assert database.query("SELECT 1")
+```
+
+### How do I apply a fixture without needing its value?
+
+Use `@use()` or the shorthand decorator:
+
+```python
+@use(setup_env)
+def test_something():
+    ...
+
+# or shorthand with single fixture:
+@setup_env
+def test_something():
+    ...
+```
+
+### How do I use fixtures from other files?
+
+Import them like any Python object:
+
+```python
+# tests/fixtures.py
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+
+# tests/test_queries.py
+from .fixtures import db
+
+def test_query():
+    database = db()
+    ...
+```
+
+### How do I parametrize tests that use unmagic fixtures?
+
+`pytest.mark.parametrize` works normally:
+
+```python
+import pytest
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+
+@pytest.mark.parametrize("query", ["SELECT 1", "SELECT 2"])
+def test_query(query):
+    database = db()
+    result = database.execute(query)
+    assert result is not None
+```
+
+### How do I use pytest-django's `db` fixture?
+
+Use `@use("db")` to apply it by name:
+
+```python
+from unmagic import use
+
+@use("db")
+def test_database():
+    from myapp.models import User
+    User.objects.create(username="test")
+    assert User.objects.count() == 1
+```
+
+## Debugging
+
+### How do I see fixture setup/teardown output?
+
+Use `pytest -s` to disable output capture:
+
+```bash
+pytest test_file.py -v -s
+```
+
+### How do I see which fixtures are active?
+
+Use `get_request()` to inspect:
+
+```python
+from unmagic import get_request
+
+def test_debug():
+    request = get_request()
+    print(request.fixturenames)  # list of active fixture names
+```
+
+## Best Practices
+
+### Where should I define fixtures?
+
+Define fixtures in a shared module (e.g., `tests/fixtures.py`) and
+import them where needed. This makes dependencies visible at the top of
+each test file.
+
+```python
+# tests/fixtures.py -- shared fixtures
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+
+@fixture(scope="session")
+def app():
+    yield create_app()
+```
+
+### Should I use the fence?
+
+The fence is useful when migrating a large codebase. It warns about
+magic fixture usage in specific modules, helping you track migration
+progress. Once migration is complete, you can keep it as a safety net or
+remove it.
+
+### How many fixtures should a test use?
+
+Keep it minimal. If a test requires more than 3-4 fixtures, consider
+composing them into a higher-level fixture that encapsulates the setup.
+
+## See Also
+
+- [Tutorial](tutorial.md):  Learn the basics
+- [API Reference](api-reference.md):  Complete API details
+- [Migration Guide](migration-guide.md):  Convert from standard pytest
+- [How-to Guides](howto/index.md):  Task-focused solutions

--- a/docs/howto/autouse-fixtures.md
+++ b/docs/howto/autouse-fixtures.md
@@ -1,0 +1,129 @@
+# How to: Use Autouse Fixtures
+
+**Problem:** You want a fixture to run automatically for tests without
+explicitly applying `@use` to each test.
+
+## Solution
+
+### Option 1: `@fixture(autouse=__file__)`
+
+Apply to all tests in the current module:
+
+```python
+# test_module.py
+from unmagic import fixture
+
+@fixture(autouse=__file__)
+def setup_env():
+    os.environ["MODE"] = "test"
+    yield
+    del os.environ["MODE"]
+
+def test_something():
+    assert os.environ["MODE"] == "test"  # fixture was applied automatically
+```
+
+### Option 2: `autouse()` from another module
+
+Register a shared fixture for autouse in specific modules:
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture
+def setup_env():
+    os.environ["MODE"] = "test"
+    yield
+    del os.environ["MODE"]
+
+# test_module.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+
+def test_something():
+    assert os.environ["MODE"] == "test"
+```
+
+### Option 3: `@fixture(autouse=True)`
+
+Apply to all tests in the entire session:
+
+```python
+@fixture(autouse=True)
+def global_setup():
+    yield
+```
+
+## Package-Level Autouse
+
+To apply a fixture to all tests in a package, use `autouse` in the
+package's `__init__.py`:
+
+```python
+# tests/__init__.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+```
+
+When `__file__` resolves to an `__init__.py`, the fixture applies to the
+entire package.
+
+## Autouse With Scopes
+
+Autouse fixtures respect their scope:
+
+```python
+# Set up once per module, applied automatically
+@fixture(scope="module", autouse=__file__)
+def module_setup():
+    yield create_module_resource()
+```
+
+## Context Managers as Autouse Fixtures
+
+You can register a context manager as an autouse fixture:
+
+```python
+from contextlib import contextmanager
+from unmagic import fixture
+
+@contextmanager
+def managed_resource():
+    resource = acquire()
+    yield resource
+    release(resource)
+
+fixture(managed_resource, scope="module", autouse=__file__)
+```
+
+## Autouse With Dependencies
+
+When an autouse fixture depends on another fixture, apply
+`@use` *inside* `@fixture(autouse=...)`:
+
+```python
+@fixture(autouse=__file__)
+@use(database)
+def seed_data():
+    db = database()
+    db.insert({"key": "value"})
+    yield
+```
+
+> [!note]
+> `@fixture(autouse=...)` must be the outermost decorator.
+
+## Warning About Late Registration
+
+If you call `autouse()` during test execution (after collection), a warning is emitted because relevant tests may have already run. Register autouse fixtures at module import time.
+
+## Related
+
+- [API Reference: fixture()](../api-reference.md#fixturefuncnone--scopefunction-autousefalse): `autouse` parameter details
+- [API Reference: autouse()](../api-reference.md#autousefixture-where): Full documentation
+- [Tutorial: Lesson 4](../tutorial.md#lesson-4-use-shorthand): Basics

--- a/docs/howto/fence-usage.md
+++ b/docs/howto/fence-usage.md
@@ -1,7 +1,7 @@
 # How to: Use the Magic Fixture Fence
 
 **Problem:** You want to enforce explicit fixture usage and get warnings
-when tests use implicit (magic) pytest fixtures.
+when tests use magic pytest fixtures.
 
 ## Solution
 

--- a/docs/howto/fence-usage.md
+++ b/docs/howto/fence-usage.md
@@ -1,0 +1,97 @@
+# How to: Use the Magic Fixture Fence
+
+**Problem:** You want to enforce explicit fixture usage and get warnings
+when tests use implicit (magic) pytest fixtures.
+
+## Solution
+
+Install a fence for your test namespace:
+
+```python
+# conftest.py
+from unmagic import fence
+
+fence.install(["mypackage.tests"])
+```
+
+Any test or fixture within `mypackage.tests` that uses magic fixtures
+will produce a warning:
+
+```
+UserWarning: mypackage/tests/test_app.py::test_query used magic fixture(s): db
+```
+
+## How It Works
+
+The fence monitors fixture resolution. When a test function or fixture
+within a fenced namespace receives fixtures via argument injection
+(the standard pytest way), a `UserWarning` is emitted.
+
+The fence does not break tests -- they still pass. It only warns, making
+it safe to install during migration.
+
+## Using the Fence as a Context Manager
+
+Install the fence with a scope using a pytest fixture:
+
+```python
+# conftest.py
+from pytest import fixture
+from unmagic import fence
+
+@fixture(scope="session", autouse=True)
+def enforce_explicit_fixtures():
+    with fence.install(["tests"]):
+        yield
+```
+
+The fence is active during the session and removed afterward.
+
+## Checking if a Function Is Fenced
+
+```python
+from unmagic import fence
+
+with fence.install(["mypackage.tests"]):
+    from mypackage.tests.test_app import test_query
+    assert fence.is_fenced(test_query)
+```
+
+## Nested Fences
+
+Fences stack. Each `install()` adds to the set of fenced modules:
+
+```python
+with fence.install(["package_a"]):
+    # package_a is fenced
+    with fence.install(["package_b"]):
+        # both package_a and package_b are fenced
+    # only package_a is fenced
+```
+
+## What the Fence Catches
+
+The fence warns about:
+
+- Test functions that receive fixtures via argument injection
+- Fixtures that depend on other fixtures via argument injection
+
+The fence does **not** warn about:
+
+- `@pytest.mark.parametrize` parameters (these are not fixtures)
+- The `request` parameter (this is a pytest built-in)
+- Fixtures applied with `@use` or called explicitly
+
+## Migration Workflow
+
+1. Install the fence for your test namespace
+2. Run tests and collect warnings
+3. Migrate warned tests/fixtures to use `@use` and explicit calls
+4. Repeat until no warnings remain
+5. Keep the fence as a safety net, or remove it
+
+## Related
+
+- [API Reference: fence.install()](../api-reference.md#fenceinstallnames-resetfalse): Full parameter details
+- [Migration Guide](../migration-guide.md): Step-by-step migration
+- [Concepts: The Fence](../concepts.md#the-fence): Design rationale

--- a/docs/howto/fixture-composition.md
+++ b/docs/howto/fixture-composition.md
@@ -1,0 +1,112 @@
+# How to: Compose Fixtures
+
+**Problem:** You want to build complex fixtures from simpler ones,
+creating a dependency chain.
+
+## Solution
+
+Use `@use` to declare fixture dependencies, then call fixtures to get
+their values:
+
+```python
+from unmagic import fixture, use
+
+@fixture
+def database():
+    yield create_database()
+
+@use(database)
+@fixture
+def user():
+    db = database()
+    user = db.create_user("test")
+    yield user
+```
+
+## Decorator Order
+
+When composing fixtures, `@use` must come *above* `@fixture`:
+
+```python
+# Correct: @use above @fixture
+@use(database)
+@fixture
+def user():
+    db = database()
+    yield db.create_user("test")
+
+# Wrong: @fixture above @use -- this will not work as expected
+@fixture
+@use(database)
+def user():
+    yield
+```
+
+## Multiple Dependencies
+
+Chain multiple fixtures with a single `@use`:
+
+```python
+@fixture
+def database():
+    yield create_database()
+
+@fixture
+def cache():
+    yield create_cache()
+
+@use(database, cache)
+@fixture
+def service():
+    db = database()
+    c = cache()
+    yield Service(db=db, cache=c)
+```
+
+## Deep Composition
+
+Fixtures can depend on other composed fixtures. Dependencies are
+resolved transitively:
+
+```python
+@fixture
+def database():
+    yield create_database()
+
+@use(database)
+@fixture
+def user():
+    db = database()
+    yield db.create_user("test")
+
+@use(user)
+@fixture
+def authenticated_client():
+    u = user()
+    yield create_client(user=u)
+
+# When this test runs, database -> user -> authenticated_client
+# are all set up in order
+def test_dashboard():
+    client = authenticated_client()
+    response = client.get("/dashboard")
+    assert response.status == 200
+```
+
+## Composing With pytest Fixtures
+
+You can compose with standard pytest fixtures using their string names:
+
+```python
+@use("db")  # pytest-django's db fixture
+@fixture
+def user():
+    from myapp.models import User
+    yield User.objects.create(username="test")
+```
+
+## Related
+
+- [Tutorial: Lesson 5](../tutorial.md#lesson-5-fixture-composition): Composition basics
+- [How to: pytest Fixture Interop](pytest-fixture-interop.md): Mix with standard fixtures
+- [API Reference: use()](../api-reference.md#usefixtures): Full parameter details

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,0 +1,23 @@
+# How-to Guides
+
+**Type:** Problem-oriented
+**Audience:** Users who need to accomplish specific tasks
+
+Each guide focuses on a single problem and provides a complete solution.
+
+## Guides
+
+| Guide                                               | Problem                                         |
+|-----------------------------------------------------|-------------------------------------------------|
+| [Scope Management](scope-management.md)             | Control when fixtures are set up and torn down  |
+| [Fixture Composition](fixture-composition.md)       | Build complex fixtures from simpler ones        |
+| [Autouse Fixtures](autouse-fixtures.md)             | Automatically apply fixtures without `@use`     |
+| [Fence Usage](fence-usage.md)                       | Enforce explicit fixture usage in your codebase |
+| [unittest Integration](unittest-integration.md)     | Use unmagic fixtures with `unittest.TestCase`   |
+| [pytest Fixture Interop](pytest-fixture-interop.md) | Mix unmagic and standard pytest fixtures        |
+
+## See Also
+
+- [Tutorial](../tutorial.md): Learn the basics step by step
+- [API Reference](../api-reference.md): Complete API details
+- [FAQ](../faq.md): Quick answers to common questions

--- a/docs/howto/pytest-fixture-interop.md
+++ b/docs/howto/pytest-fixture-interop.md
@@ -1,0 +1,126 @@
+# How to: Interop With Standard pytest Fixtures
+
+**Problem:** You need to use standard pytest fixtures (built-in or from
+plugins) alongside unmagic fixtures.
+
+## Solution
+
+There are two ways to access standard pytest fixtures:
+
+### Method 1: `@use("fixture_name")`
+
+Apply a pytest fixture by name:
+
+```python
+from unmagic import use
+
+@use("db")  # pytest-django's db fixture
+def test_models():
+    from myapp.models import User
+    User.objects.create(username="test")
+    assert User.objects.count() == 1
+```
+
+This is useful for fixtures with side effects (like `db`, which enables
+database access) where you don't need the fixture's return value.
+
+### Method 2: `get_request().getfixturevalue("name")`
+
+Retrieve a fixture's value by name:
+
+```python
+from unmagic import get_request
+
+def test_capture():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+```
+
+## Common pytest Fixtures
+
+### `capsys` -- Capture output
+
+```python
+from unmagic import get_request
+
+def test_output():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    assert capsys.readouterr().out == "hello\n"
+```
+
+### `tmp_path` -- Temporary directory
+
+```python
+from unmagic import get_request
+
+def test_files():
+    tmp = get_request().getfixturevalue("tmp_path")
+    f = tmp / "data.txt"
+    f.write_text("hello")
+    assert f.read_text() == "hello"
+```
+
+### `monkeypatch` -- Patching
+
+```python
+from unmagic import get_request
+
+def test_env():
+    mp = get_request().getfixturevalue("monkeypatch")
+    mp.setenv("MODE", "test")
+    import os
+    assert os.environ["MODE"] == "test"
+```
+
+### Plugin fixtures (e.g., pytest-django `db`)
+
+```python
+from unmagic import use
+
+@use("db")
+def test_database():
+    from myapp.models import User
+    User.objects.create(username="test")
+```
+
+## Wrapping a pytest Fixture as Unmagic
+
+Use `fixture("name")` to create a reusable unmagic wrapper:
+
+```python
+from unmagic import fixture
+
+db = fixture("db")
+
+# Now use like any unmagic fixture
+@use(db)
+def test_models():
+    ...
+```
+
+## Using pytest Fixtures in Unmagic Fixture Dependencies
+
+```python
+from unmagic import fixture, use
+
+@use("db")
+@fixture
+def test_user():
+    from myapp.models import User
+    yield User.objects.create(username="test")
+    User.objects.filter(username="test").delete()
+
+def test_user_exists():
+    user = test_user()
+    from myapp.models import User
+    assert User.objects.filter(pk=user.pk).exists()
+```
+
+## Related
+
+- [API Reference: use()](../api-reference.md#usefixtures): Accepts fixture names as strings
+- [API Reference: get_request()](../api-reference.md#get_request): Access the pytest request
+- [Migration Guide: Example 7](../migration-guide.md#example-7-using-standard-pytest-fixtures): Interop examples

--- a/docs/howto/scope-management.md
+++ b/docs/howto/scope-management.md
@@ -1,0 +1,115 @@
+# How to: Manage Fixture Scopes
+
+**Problem:** You want to control when fixtures are set up and torn down
+to optimize test performance or share state across tests.
+
+## Solution
+
+Pass the `scope` parameter to `@fixture`:
+
+```python
+from unmagic import fixture
+
+@fixture(scope="module")
+def expensive_resource():
+    resource = create_expensive_resource()
+    yield resource
+    resource.cleanup()
+```
+
+## Available Scopes
+
+| Scope                  | Setup                        | Teardown                   |
+|------------------------|------------------------------|----------------------------|
+| `"function"` (default) | Before each test             | After each test            |
+| `"class"`              | Before first test in class   | After last test in class   |
+| `"module"`             | Before first test in module  | After last test in module  |
+| `"package"`            | Before first test in package | After last test in package |
+| `"session"`            | Once per session             | At end of session          |
+
+## Examples
+
+### Function scope (default)
+
+Each test gets a fresh instance:
+
+```python
+@fixture
+def items():
+    yield []
+
+def test_one():
+    lst = items()
+    lst.append(1)
+    assert lst == [1]
+
+def test_two():
+    lst = items()
+    assert lst == []  # fresh list
+```
+
+### Module scope
+
+Shared across all tests in the file:
+
+```python
+@fixture(scope="module")
+def db():
+    conn = connect_to_database()
+    yield conn
+    conn.close()
+
+def test_read():
+    database = db()
+    assert database.query("SELECT 1")
+
+def test_write():
+    database = db()  # same connection as test_read
+    database.execute("INSERT ...")
+```
+
+### Session scope
+
+Shared across the entire test run:
+
+```python
+@fixture(scope="session")
+def app():
+    application = create_app()
+    yield application
+    application.shutdown()
+```
+
+### Combining scopes
+
+Higher-scoped fixtures can be used by lower-scoped ones:
+
+```python
+@fixture(scope="session")
+def app():
+    yield create_app()
+
+@use(app)
+@fixture(scope="function")
+def client():
+    application = app()
+    yield application.test_client()
+```
+
+## When to Use Each Scope
+
+- **function**: Default. Use when each test needs clean state.
+- **class**: Use when tests within a class share setup but classes don't.
+- **module**: Use for expensive setup shared across a file (e.g., database connection).
+- **package**: Use for setup shared across a directory of test files.
+- **session**: Use for one-time global setup (e.g., starting an application).
+
+> [!warning]
+> A fixture cannot depend on a fixture with a narrower scope. For
+> example, a session-scoped fixture cannot use a function-scoped
+> fixture.
+
+## Related
+
+- [API Reference: fixture()](../api-reference.md#fixturefuncnone--scopefunction-autousefalse): Full parameter details
+- [Tutorial: Lesson 6](../tutorial.md#lesson-6-fixture-scopes): Scope basics

--- a/docs/howto/unittest-integration.md
+++ b/docs/howto/unittest-integration.md
@@ -1,0 +1,84 @@
+# How to: Use Fixtures With unittest.TestCase
+
+**Problem:** You want to use pytest-unmagic fixtures with
+`unittest.TestCase` tests, which don't support standard pytest
+fixtures.
+
+## Solution
+
+Apply fixtures to the TestCase class with `@use`:
+
+```python
+import unittest
+from unmagic import fixture, use
+
+@fixture
+def db():
+    connection = create_database()
+    yield connection
+    connection.close()
+
+@use(db)
+class TestQueries(unittest.TestCase):
+    def test_insert(self):
+        database = db()
+        database.insert({"key": "value"})
+        self.assertEqual(database.get("key"), "value")
+
+    def test_query(self):
+        database = db()
+        self.assertTrue(database.query("SELECT 1"))
+```
+
+## How It Works
+
+When `@use` is applied to a class, it wraps each test method so that the
+fixtures are set up before the method runs and torn down afterward.
+This works with any class, including `unittest.TestCase`.
+
+## Multiple Fixtures
+
+Apply multiple fixtures at once:
+
+```python
+@use(db, cache, auth)
+class TestApp(unittest.TestCase):
+    def test_with_all_fixtures(self):
+        database = db()
+        cache_client = cache()
+        ...
+```
+
+## Scoped Fixtures
+
+Fixture scopes work as expected. A class-scoped fixture is shared across
+all methods in the TestCase:
+
+```python
+@fixture(scope="class")
+def shared_db():
+    yield create_database()
+
+@use(shared_db)
+class TestDatabase(unittest.TestCase):
+    def test_one(self):
+        db = shared_db()  # same instance
+        db.insert({"a": 1})
+
+    def test_two(self):
+        db = shared_db()  # same instance as test_one
+        self.assertIn("a", db.keys())
+```
+
+## Why This Matters
+
+Standard pytest fixtures cannot be injected into `unittest.TestCase`
+methods. This is a long-standing limitation of pytest. pytest-unmagic
+works around this because fixtures are applied via decorators and
+called explicitly, not injected via argument names.
+
+## Related
+
+- [Tutorial: Lesson 7](../tutorial.md#lesson-7-applying-fixtures-to-classes): Class-based test basics
+- [Migration Guide: Example 6](../migration-guide.md#example-6-unittesttestcase-new-capability): TestCase migration
+- [API Reference: use()](../api-reference.md#usefixtures): Full parameter details

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,78 @@
+# pytest-unmagic Documentation
+
+**Version:** 1.0.1
+**Type:** Documentation hub
+**Source:** [GitHub](https://github.com/dimagi/pytest-unmagic)
+**Package:** [PyPI](https://pypi.org/project/pytest-unmagic/)
+
+pytest-unmagic replaces pytest's implicit fixture injection with
+conventional Python imports. Fixtures are explicitly imported, applied
+with decorators, and called to retrieve values -- no name-matching
+magic.
+
+## I want to...
+
+| Goal                              | Document                              |
+|-----------------------------------|---------------------------------------|
+| Learn pytest-unmagic from scratch | [Tutorial](tutorial.md)               |
+| Migrate existing pytest fixtures  | [Migration Guide](migration-guide.md) |
+| Solve a specific problem          | [How-to Guides](howto/index.md)       |
+| Look up API details               | [API Reference](api-reference.md)     |
+| Understand the philosophy         | [Concepts](concepts.md)               |
+| Fix an error or common issue      | [FAQ](faq.md)                         |
+
+## Quick Start
+
+```bash
+pip install pytest-unmagic
+```
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture
+def greeting():
+    yield "hello"
+
+# test_example.py
+from unmagic import use
+from fixtures import greeting
+
+@use(greeting)
+def test_greeting():
+    value = greeting()
+    assert value == "hello"
+```
+
+```bash
+pytest test_example.py -v
+```
+
+## Documentation Overview
+
+This documentation follows the [Diataxis](https://diataxis.fr/) framework:
+
+- [Tutorial](tutorial.md): Learning-oriented, hands-on lessons (~30 minutes)
+
+- [How-to Guides](howto/index.md): Problem-oriented, task-focused solutions
+
+- [API Reference](api-reference.md): Information-oriented, complete
+  technical specification
+
+- [Concepts](concepts.md): Understanding-oriented, philosophy and design
+
+Additional resources:
+
+- [Migration Guide](migration-guide.md): Convert from standard pytest
+  fixtures step by step
+
+- [FAQ](faq.md): Common questions, error messages, and troubleshooting
+
+- [CHANGELOG](https://github.com/dimagi/pytest-unmagic/blob/main/CHANGELOG.md):
+  Release history
+
+## Compatibility
+
+- **Python:** 3.9, 3.10, 3.11, 3.12, 3.13
+- **pytest:** 8.1, 8.2, 8.3, 8.4

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 **Source:** [GitHub](https://github.com/dimagi/pytest-unmagic)
 **Package:** [PyPI](https://pypi.org/project/pytest-unmagic/)
 
-pytest-unmagic replaces pytest's implicit fixture injection with
+pytest-unmagic replaces pytest's magic fixture injection with
 conventional Python imports. Fixtures are explicitly imported, applied
 with decorators, and called to retrieve values -- no name-matching
 magic.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,386 @@
+# Migration Guide
+
+**Type:** Step-by-step tutorial for experienced pytest users
+**Time:** ~20 minutes
+**Prerequisites:** Familiarity with standard pytest fixtures
+**Next:** [How-to Guides](howto/index.md) or [API Reference](api-reference.md)
+
+This guide shows how to convert standard pytest fixtures to
+pytest-unmagic, one pattern at a time.
+
+## Quick Reference
+
+| Standard pytest                       | pytest-unmagic                                           |
+|---------------------------------------|----------------------------------------------------------|
+| `@pytest.fixture`                     | `from unmagic import fixture; @fixture`                  |
+| `def test(fix):` (argument injection) | `@use(fix)` + `fix()` inside test                        |
+| `conftest.py` auto-discovery          | Explicit `import` from any module                        |
+| `@pytest.fixture(autouse=True)`       | `@fixture(autouse=__file__)` or `autouse(fix, __file__)` |
+| `request.getfixturevalue("name")`     | `get_request().getfixturevalue("name")`                  |
+| `@pytest.fixture(scope="module")`     | `@fixture(scope="module")`                               |
+
+## Migration Strategy
+
+pytest-unmagic supports gradual migration. You don't need to convert
+everything at once.
+
+**Recommended approach:**
+
+1. Install pytest-unmagic
+2. Write new fixtures with `@fixture`
+3. Convert existing fixtures file by file
+4. Use the fence to track progress (optional)
+
+## Example 1: Basic Fixture
+
+**Before (standard pytest):**
+
+```python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def db():
+    connection = create_connection()
+    yield connection
+    connection.close()
+
+# test_app.py
+def test_query(db):
+    assert db.query("SELECT 1")
+```
+
+**After (pytest-unmagic):**
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture
+def db():
+    connection = create_connection()
+    yield connection
+    connection.close()
+
+# test_app.py
+from fixtures import db
+
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
+**What changed:**
+
+1. `@pytest.fixture` becomes `@fixture` (from `unmagic`)
+2. Fixture moves from `conftest.py` to a regular module (e.g., `fixtures.py`)
+3. Test imports the fixture explicitly
+4. Test calls `db()` instead of receiving it as an argument
+
+## Example 2: Fixture With Setup/Teardown Side Effects
+
+When a fixture's value isn't used, apply it with `@use` instead of
+calling it.
+
+**Before:**
+
+```python
+@pytest.fixture(autouse=True)
+def clean_cache():
+    yield
+    cache.clear()
+
+def test_caching():
+    cache.set("key", "value")
+    assert cache.get("key") == "value"
+```
+
+**After:**
+
+```python
+from unmagic import fixture, use
+
+@fixture
+def clean_cache():
+    yield
+    cache.clear()
+
+@use(clean_cache)
+def test_caching():
+    cache.set("key", "value")
+    assert cache.get("key") == "value"
+```
+
+## Example 3: Fixture With Scope
+
+**Before:**
+
+```python
+@pytest.fixture(scope="session")
+def app():
+    app = create_app()
+    yield app
+    app.shutdown()
+
+def test_homepage(app):
+    response = app.get("/")
+    assert response.status == 200
+```
+
+**After:**
+
+```python
+from unmagic import fixture
+
+@fixture(scope="session")
+def app():
+    application = create_app()
+    yield application
+    application.shutdown()
+
+def test_homepage():
+    application = app()
+    response = application.get("/")
+    assert response.status == 200
+```
+
+## Example 4: Autouse Fixtures
+
+**Before:**
+
+```python
+# conftest.py
+@pytest.fixture(autouse=True)
+def reset_state():
+    yield
+    global_state.reset()
+```
+
+**After (module-level):**
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture
+def reset_state():
+    yield
+    global_state.reset()
+
+# test_module.py
+from unmagic import autouse
+from fixtures import reset_state
+
+autouse(reset_state, __file__)
+```
+
+**After (all tests):**
+
+```python
+# fixtures.py
+from unmagic import fixture
+
+@fixture(autouse=True)
+def reset_state():
+    yield
+    global_state.reset()
+```
+
+## Example 5: Class-Based Tests
+
+**Before:**
+
+```python
+@pytest.fixture
+def items():
+    return []
+
+class TestCart:
+    def test_add(self, items):
+        items.append("apple")
+        assert items == ["apple"]
+```
+
+**After:**
+
+```python
+from unmagic import fixture, use
+
+@fixture
+def items():
+    yield []
+
+@use(items)
+class TestCart:
+    def test_add(self):
+        cart = items()
+        cart.append("apple")
+        assert cart == ["apple"]
+```
+
+## Example 6: unittest.TestCase (New Capability)
+
+Standard pytest fixtures don't work with `unittest.TestCase`.
+pytest-unmagic does.
+
+```python
+import unittest
+from unmagic import fixture, use
+
+@fixture
+def db():
+    yield create_database()
+
+@use(db)
+class TestDatabase(unittest.TestCase):
+    def test_query(self):
+        database = db()
+        self.assertTrue(database.query("SELECT 1"))
+```
+
+## Example 7: Using Standard pytest Fixtures
+
+You can still use standard pytest fixtures from unmagic code:
+
+**Access by name with `@use`:**
+
+```python
+from unmagic import use
+
+@use("db")  # pytest-django's db fixture
+def test_models():
+    from myapp.models import User
+    User.objects.create(username="test")
+```
+
+**Access via `get_request()`:**
+
+```python
+from unmagic import get_request
+
+def test_output():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    assert capsys.readouterr().out == "hello\n"
+```
+
+## Example 8: Parametrize
+
+`pytest.mark.parametrize` works the same way:
+
+```python
+import pytest
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+
+@pytest.mark.parametrize("table", ["users", "orders"])
+def test_table_exists(table):
+    database = db()
+    assert database.has_table(table)
+```
+
+## Migration Patterns
+
+### File-by-file migration
+
+1. Pick a test file
+2. Convert its fixtures to unmagic
+3. Move fixtures to a shared module (e.g., `fixtures.py`)
+4. Update imports in the test file
+5. Run tests to verify
+
+### Hybrid approach
+
+Keep both styles during migration. Standard pytest fixtures and unmagic
+fixtures can coexist.
+
+### Using the fence for tracking
+
+Install a fence to get warnings about remaining magic fixtures:
+
+```python
+# conftest.py
+from unmagic import fence
+
+fence.install(["tests"])
+```
+
+Then run tests and look for warnings:
+
+```
+UserWarning: tests/test_app.py::test_query used magic fixture(s): db
+```
+
+These warnings show which tests still use implicit fixtures.
+
+## Common Pitfalls
+
+### Forgetting to call the fixture
+
+```python
+# Wrong -- fixture is not called, `db` is the fixture object itself
+def test_query():
+    assert db.query("SELECT 1")  # AttributeError
+
+# Correct -- call the fixture to get its value
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
+### Wrong decorator order
+
+```python
+# Wrong -- @use must come before @fixture
+@fixture
+@use(dependency)
+def my_fixture():
+    yield
+
+# Correct
+@use(dependency)
+@fixture
+def my_fixture():
+    yield
+```
+
+### Forgetting to apply the fixture
+
+```python
+# Wrong -- fixture is never set up
+from fixtures import db
+
+def test_query():
+    database = db()  # Error: fixture not set up
+
+# Correct -- apply with @use (or use shorthand)
+@use(db)
+def test_query():
+    database = db()
+```
+
+If you call a fixture without applying it first (via `@use` or
+shorthand), it will still work for fixtures that are first used in the
+same test. But applying fixtures explicitly with `@use` ensures proper
+ordering when fixtures depend on each other.
+
+## Checklist
+
+After migrating a file:
+
+- [ ] All fixtures use `@fixture` from `unmagic`
+- [ ] All fixture dependencies use `@use` or shorthand
+- [ ] Fixtures are imported explicitly (no conftest.py magic)
+- [ ] Tests pass with `pytest -v`
+- [ ] No fence warnings (if fence is installed)
+
+## See Also
+
+- [Tutorial](tutorial.md): Learn from scratch
+- [API Reference](api-reference.md): Complete API details
+- [How-to: pytest Fixture Interop](howto/pytest-fixture-interop.md): Mix
+  with standard fixtures
+- [Concepts](concepts.md) -- Understand the design philosophy

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,437 @@
+# Tutorial
+
+**Type:** Learning-oriented
+**Time:** ~30 minutes
+**Prerequisites:** Python basics, pytest installed
+**Next:** [Migration Guide](migration-guide.md) or [How-to Guides](howto/index.md)
+
+This tutorial teaches pytest-unmagic through hands-on practice. Each
+lesson builds on the previous one.
+
+## Setup
+
+Install pytest-unmagic:
+
+```bash
+pip install pytest-unmagic
+```
+
+Create a working directory for the tutorial:
+
+```bash
+mkdir unmagic-tutorial && cd unmagic-tutorial
+```
+
+## Lesson 1: Your First Unmagic Fixture
+
+Create `test_basics.py`:
+
+```python
+# test_basics.py
+from unmagic import fixture
+
+@fixture
+def greeting():
+    yield "hello"
+
+def test_greeting():
+    value = greeting()
+    assert value == "hello"
+```
+
+Run it:
+
+```bash
+pytest test_basics.py -v
+```
+
+Expected output:
+
+```
+test_basics.py::test_greeting PASSED
+```
+
+**What happened:**
+
+1. `@fixture` defines a fixture that yields a value (`"hello"`)
+2. `greeting()` retrieves the fixture's value inside the test
+3. pytest-unmagic manages setup and teardown automatically
+
+Notice that calling `greeting()` inside a test does not re-execute the
+fixture function. It returns the value that was already yielded when
+the fixture was set up.
+
+## Lesson 2: Fixture Setup and Teardown
+
+Fixtures can run code before and after yielding. This is useful for
+resource management.
+
+Create `test_teardown.py`:
+
+```python
+# test_teardown.py
+from unmagic import fixture
+
+@fixture
+def db_connection():
+    # Setup: runs before the test
+    print("connecting to database")
+    connection = {"connected": True}
+    yield connection
+    # Teardown: runs after the test
+    print("closing database connection")
+    connection["connected"] = False
+
+def test_database():
+    conn = db_connection()
+    assert conn["connected"] is True
+```
+
+Run it:
+
+```bash
+pytest test_teardown.py -v -s
+```
+
+Expected output:
+
+```
+test_teardown.py::test_database connecting to database
+closing database connection
+PASSED
+```
+
+> [!IMPORTANT]
+> Code before `yield` is setup, code after `yield` is teardown. The
+> fixture must yield exactly once.
+
+## Lesson 3: Applying Fixtures with @use
+
+When a fixture has side effects but you don't need its return value, use
+the `@use` decorator to apply it.
+
+Create `test_use.py`:
+
+```python
+# test_use.py
+from unmagic import fixture, use
+
+traces = []
+
+@fixture
+def tracer():
+    traces.clear()
+    yield
+    print(f"traces: {traces}")
+
+@use(tracer)
+def test_one():
+    traces.append("one")
+    assert traces == ["one"]
+
+@use(tracer)
+def test_two():
+    traces.append("two")
+    assert traces == ["two"]
+```
+
+Run it:
+
+```bash
+pytest test_use.py -v -s
+```
+
+Expected output:
+
+```
+test_use.py::test_one traces: ['one']
+PASSED
+test_use.py::test_two traces: ['two']
+PASSED
+```
+
+> [!IMPORTANT]
+> `@use(tracer)` sets up and tears down `tracer` for each test, but
+> doesn't pass a value. The test function takes no arguments.
+
+## Lesson 4: @use Shorthand
+
+When applying a single fixture, you can use the fixture itself as a
+decorator instead of `@use()`.
+
+Create `test_shorthand.py`:
+
+```python
+# test_shorthand.py
+from unmagic import fixture
+
+traces = []
+
+@fixture
+def tracer():
+    traces.clear()
+    yield
+
+# These two are equivalent:
+
+@tracer
+def test_with_shorthand():
+    traces.append("shorthand")
+    assert traces == ["shorthand"]
+```
+
+Run it:
+
+```bash
+pytest test_shorthand.py -v
+```
+
+> [!IMPORTANT]
+> `@tracer` is shorthand for `@use(tracer)` when applying a single
+> fixture. This only works for applying the fixture as a decorator, not
+> for retrieving its value.
+
+## Lesson 5: Fixture Composition
+
+Fixtures can use other fixtures. Decorate with `@use` to chain
+dependencies.
+
+Create `test_composition.py`:
+
+```python
+# test_composition.py
+from unmagic import fixture, use
+
+@fixture
+def database():
+    db = {"users": []}
+    yield db
+    db["users"].clear()
+
+@use(database)
+@fixture
+def admin_user():
+    db = database()
+    db["users"].append({"name": "admin", "role": "admin"})
+    yield db["users"][-1]
+
+def test_admin_exists():
+    user = admin_user()
+    assert user["name"] == "admin"
+    assert user["role"] == "admin"
+
+def test_database_has_admin():
+    admin = admin_user()
+    db = database()
+    assert admin in db["users"]
+```
+
+Run it:
+
+```bash
+pytest test_composition.py -v
+```
+
+> [!IMPORTANT]
+> `@use(database)` on `admin_user` ensures `database` is set up before
+> `admin_user`. Apply `@use` *before* `@fixture` (decorators apply
+> bottom-up).
+
+## Lesson 6: Fixture Scopes
+
+By default, fixtures have `function` scope -- they are set up and torn
+down for each test. You can change this with the `scope` parameter.
+
+Create `test_scopes.py`:
+
+```python
+# test_scopes.py
+from unmagic import fixture
+
+setup_count = 0
+
+@fixture(scope="module")
+def shared_resource():
+    global setup_count
+    setup_count += 1
+    print(f"\nsetup #{setup_count}")
+    yield {"id": setup_count}
+    print(f"teardown #{setup_count}")
+
+def test_first():
+    resource = shared_resource()
+    assert resource["id"] == 1
+
+def test_second():
+    resource = shared_resource()
+    # Same instance -- module-scoped fixture is set up once
+    assert resource["id"] == 1
+
+def test_setup_count():
+    assert setup_count == 1
+```
+
+Run it:
+
+```bash
+pytest test_scopes.py -v -s
+```
+
+Expected output:
+
+```
+test_scopes.py::test_first
+setup #1
+PASSED
+test_scopes.py::test_second PASSED
+test_scopes.py::test_setup_count PASSED
+teardown #1
+```
+
+Available scopes: `"function"` (default), `"class"`, `"module"`,
+`"package"`, `"session"`.
+
+## Lesson 7: Applying Fixtures to Classes
+
+The `@use` decorator works on test classes, applying fixtures to every
+test method in the class.
+
+Create `test_classes.py`:
+
+```python
+# test_classes.py
+from unmagic import fixture, use
+
+@fixture
+def items():
+    yield []
+
+@use(items)
+class TestShoppingCart:
+    def test_add_item(self):
+        cart = items()
+        cart.append("apple")
+        assert "apple" in cart
+
+    def test_empty_cart(self):
+        cart = items()
+        assert cart == []
+```
+
+Run it:
+
+```bash
+pytest test_classes.py -v
+```
+
+Expected output:
+
+```
+test_classes.py::TestShoppingCart::test_add_item PASSED
+test_classes.py::TestShoppingCart::test_empty_cart PASSED
+```
+
+> [!IMPORTANT]
+> `@use(items)` on the class applies the fixture to all test methods.
+> Each test gets a fresh fixture instance (function scope by default).
+
+This also works with `unittest.TestCase` -- unlike standard pytest
+fixtures.
+
+## Lesson 8: Accessing pytest Fixtures
+
+You can access standard pytest fixtures (like `capsys`, `tmp_path`,
+`monkeypatch`) using `get_request()`.
+
+Create `test_pytest_interop.py`:
+
+```python
+# test_pytest_interop.py
+from unmagic import get_request
+
+def test_capture_output():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+```
+
+You can also apply pytest fixtures by name with `@use`:
+
+```python
+# test_use_pytest.py
+from unmagic import use
+
+@use("tmp_path")
+def test_with_tmp_path():
+    from unmagic import get_request
+    tmp = get_request().getfixturevalue("tmp_path")
+    p = tmp / "test.txt"
+    p.write_text("hello")
+    assert p.read_text() == "hello"
+```
+
+Run them:
+
+```bash
+pytest test_pytest_interop.py test_use_pytest.py -v
+```
+
+> [!IMPORTANT]
+> `get_request()` gives access to the active pytest request, bridging
+> unmagic and standard pytest fixtures.
+
+## Lesson 9: The Fence Feature
+
+The fence warns you when tests use "magic" (implicit) pytest fixtures,
+helping enforce explicit fixture usage.
+
+Create `conftest.py`:
+
+```python
+# conftest.py
+from unmagic import fence
+
+fence.install(["test_fenced"])
+```
+
+Create `test_fenced.py`:
+
+```python
+# test_fenced.py
+from pytest import fixture
+
+@fixture
+def magic_value():
+    return 42
+
+# This test uses a magic fixture -- fence will warn
+def test_magic(magic_value):
+    assert magic_value == 42
+```
+
+Run it:
+
+```bash
+pytest test_fenced.py -v
+```
+
+Expected output includes:
+
+```
+warnings summary
+  ... UserWarning: test_fenced.py::test_magic used magic fixture(s): magic_value
+```
+
+The test still passes, but you get a warning. This helps with gradual
+migration to explicit fixtures.
+
+## Next Steps
+
+You now know the core features of pytest-unmagic. Here's where to go
+next:
+
+- [Migration Guide](migration-guide.md): Convert existing pytest fixtures to unmagic
+- [How-to Guides](howto/index.md): Solve specific problems
+- [API Reference](api-reference.md): Complete API details
+- [Concepts](concepts.md): Understand the design philosophy

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -383,7 +383,7 @@ pytest test_pytest_interop.py test_use_pytest.py -v
 
 ## Lesson 9: The Fence Feature
 
-The fence warns you when tests use "magic" (implicit) pytest fixtures,
+The fence warns you when tests use magic pytest fixtures,
 helping enforce explicit fixture usage.
 
 Create `conftest.py`:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+Runnable code examples for pytest-unmagic.
+
+## Directories
+
+| Directory                | Description                                           |
+|--------------------------|-------------------------------------------------------|
+| [basic/](basic/)         | Core features: fixtures, scopes, composition, classes |
+| [migration/](migration/) | Before/after comparison with standard pytest          |
+
+## Running All Examples
+
+```bash
+pip install pytest-unmagic
+pytest examples/ -v
+```
+
+## Documentation
+
+- [Tutorial](../docs/tutorial.md): Hands-on introduction
+- [Migration Guide](../docs/migration-guide.md): Convert from standard pytest
+- [API Reference](../docs/api-reference.md): Complete API details

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,37 @@
+# Basic Examples
+
+Self-contained examples demonstrating core pytest-unmagic features.
+
+## Files
+
+| File                  | Demonstrates                               |
+|-----------------------|--------------------------------------------|
+| `fixtures.py`         | Shared fixture definitions                 |
+| `test_simple.py`      | Basic fixture usage, `@use`, and shorthand |
+| `test_scope.py`       | Module-scoped fixtures                     |
+| `test_composition.py` | Building fixtures from other fixtures      |
+| `test_classes.py`     | Class-based tests and `unittest.TestCase`  |
+
+## Running
+
+```bash
+pip install pytest-unmagic
+pytest examples/basic/ -v
+```
+
+## Expected Output
+
+```
+examples/basic/test_simple.py::test_greeting_value PASSED
+examples/basic/test_simple.py::test_tracing PASSED
+examples/basic/test_simple.py::test_shorthand PASSED
+examples/basic/test_scope.py::test_first PASSED
+examples/basic/test_scope.py::test_second PASSED
+examples/basic/test_scope.py::test_setup_only_once PASSED
+examples/basic/test_composition.py::test_admin_exists PASSED
+examples/basic/test_composition.py::test_database_has_admin PASSED
+examples/basic/test_classes.py::TestWithUse::test_add PASSED
+examples/basic/test_classes.py::TestWithUse::test_empty PASSED
+examples/basic/test_classes.py::TestWithTestCase::test_add PASSED
+examples/basic/test_classes.py::TestWithTestCase::test_empty PASSED
+```

--- a/examples/basic/fixtures.py
+++ b/examples/basic/fixtures.py
@@ -1,0 +1,24 @@
+# examples/basic/fixtures.py
+"""Shared fixtures for basic examples."""
+from unmagic import fixture
+
+
+@fixture
+def greeting():
+    """A simple fixture that yields a string value."""
+    yield "hello"
+
+
+@fixture
+def items():
+    """A fixture that yields a fresh list for each test."""
+    yield []
+
+
+@fixture(scope="module")
+def database():
+    """A module-scoped fixture simulating a database connection."""
+    db = {"connected": True, "data": {}}
+    yield db
+    db["connected"] = False
+    db["data"].clear()

--- a/examples/basic/test_classes.py
+++ b/examples/basic/test_classes.py
@@ -1,0 +1,41 @@
+# examples/basic/test_classes.py
+"""Class-based test examples, including unittest.TestCase.
+
+Run: pytest examples/basic/test_classes.py -v
+"""
+import unittest
+
+from unmagic import fixture, use
+
+
+@fixture
+def items():
+    yield []
+
+
+@use(items)
+class TestWithUse:
+    """Apply fixture to all methods in a regular test class."""
+
+    def test_add(self):
+        cart = items()
+        cart.append("apple")
+        assert cart == ["apple"]
+
+    def test_empty(self):
+        cart = items()
+        assert cart == []
+
+
+@use(items)
+class TestWithTestCase(unittest.TestCase):
+    """Apply fixture to unittest.TestCase -- not possible with standard pytest."""
+
+    def test_add(self):
+        cart = items()
+        cart.append("banana")
+        self.assertEqual(cart, ["banana"])
+
+    def test_empty(self):
+        cart = items()
+        self.assertEqual(cart, [])

--- a/examples/basic/test_composition.py
+++ b/examples/basic/test_composition.py
@@ -1,0 +1,34 @@
+# examples/basic/test_composition.py
+"""Fixture composition examples.
+
+Run: pytest examples/basic/test_composition.py -v
+"""
+from unmagic import fixture, use
+
+
+@fixture
+def database():
+    db = {"users": []}
+    yield db
+    db["users"].clear()
+
+
+@use(database)
+@fixture
+def admin_user():
+    db = database()
+    user = {"name": "admin", "role": "admin"}
+    db["users"].append(user)
+    yield user
+
+
+def test_admin_exists():
+    user = admin_user()
+    assert user["name"] == "admin"
+    assert user["role"] == "admin"
+
+
+def test_database_has_admin():
+    admin = admin_user()
+    db = database()
+    assert admin in db["users"]

--- a/examples/basic/test_scope.py
+++ b/examples/basic/test_scope.py
@@ -1,0 +1,31 @@
+# examples/basic/test_scope.py
+"""Fixture scope examples.
+
+Run: pytest examples/basic/test_scope.py -v -s
+"""
+from unmagic import fixture
+
+setup_count = 0
+
+
+@fixture(scope="module")
+def shared_resource():
+    """Set up once for the entire module."""
+    global setup_count
+    setup_count += 1
+    yield {"id": setup_count}
+
+
+def test_first():
+    resource = shared_resource()
+    assert resource["id"] == 1
+
+
+def test_second():
+    resource = shared_resource()
+    # Same instance -- module scope means one setup per module
+    assert resource["id"] == 1
+
+
+def test_setup_only_once():
+    assert setup_count == 1

--- a/examples/basic/test_simple.py
+++ b/examples/basic/test_simple.py
@@ -1,0 +1,41 @@
+# examples/basic/test_simple.py
+"""Basic fixture usage examples.
+
+Run: pytest examples/basic/test_simple.py -v
+"""
+from unmagic import fixture, use
+
+
+@fixture
+def greeting():
+    yield "hello"
+
+
+# Call a fixture to retrieve its value
+def test_greeting_value():
+    value = greeting()
+    assert value == "hello"
+
+
+# Apply a fixture with @use for side effects
+traces = []
+
+
+@fixture
+def tracer():
+    traces.clear()
+    yield
+    # teardown: traces are available here
+
+
+@use(tracer)
+def test_tracing():
+    traces.append("one")
+    assert traces == ["one"]
+
+
+# Shorthand: use fixture directly as decorator
+@tracer
+def test_shorthand():
+    traces.append("two")
+    assert traces == ["two"]

--- a/examples/migration/README.md
+++ b/examples/migration/README.md
@@ -1,0 +1,26 @@
+# Migration Examples
+
+Side-by-side comparison of standard pytest fixtures and pytest-unmagic.
+
+## Files
+
+| File               | Description                               |
+|--------------------|-------------------------------------------|
+| `before_pytest.py` | Standard pytest patterns (for reference)  |
+| `after_unmagic.py` | Equivalent pytest-unmagic code (runnable) |
+
+## Running
+
+Only the "after" file is runnable as a test:
+
+```bash
+pytest examples/migration/after_unmagic.py -v
+```
+
+## Key Differences
+
+1. `@pytest.fixture` becomes `@fixture` (from `unmagic`)
+2. Argument injection becomes explicit `@use` + `fixture()` call
+3. `conftest.py` discovery becomes Python imports
+4. `autouse=True` becomes `autouse=__file__` (module-scoped) or `True` (global)
+5. Fixture composition uses `@use(dep)` instead of argument injection

--- a/examples/migration/after_unmagic.py
+++ b/examples/migration/after_unmagic.py
@@ -1,0 +1,65 @@
+# examples/migration/after_unmagic.py
+"""
+After Migration: pytest-unmagic equivalents
+
+Compare with before_pytest.py. Run this file:
+
+    pytest examples/migration/after_unmagic.py -v
+
+"""
+from unmagic import fixture, use
+
+
+# 1. Basic fixture -- @pytest.fixture -> @fixture, return -> yield
+@fixture
+def db():
+    connection = {"connected": True, "data": {}}
+    yield connection
+    connection["connected"] = False
+
+
+# 2. Fixture with scope -- same scope parameter
+@fixture(scope="module")
+def app():
+    application = {"started": True}
+    yield application
+    application["started"] = False
+
+
+# 3. Autouse fixture -- autouse=__file__ limits to this module
+@fixture(autouse=__file__)
+def clean_state():
+    yield
+    # cleanup after each test
+
+
+# 4. Fixture using another fixture -- @use chains dependencies
+@use(db)
+@fixture
+def admin_user():
+    database = db()  # call to get value (not argument injection)
+    user = {"name": "admin"}
+    database["data"]["admin"] = user
+    yield user
+
+
+# 5. Tests -- no arguments, fixtures called explicitly
+def test_query():
+    database = db()
+    database["data"]["key"] = "value"
+    assert database["data"]["key"] == "value"
+
+
+@use(admin_user)
+def test_admin():
+    user = admin_user()
+    database = db()
+    assert database["data"]["admin"] == user
+
+
+# 6. Class-based test -- @use on class applies to all methods
+@use(app)
+class TestApp:
+    def test_started(self):
+        application = app()
+        assert application["started"] is True

--- a/examples/migration/before_pytest.py
+++ b/examples/migration/before_pytest.py
@@ -1,0 +1,61 @@
+# examples/migration/before_pytest.py
+"""
+Before Migration: Standard pytest fixture patterns
+
+This file shows common pytest patterns. Compare with after_unmagic.py
+to see the equivalent pytest-unmagic code.
+
+.. note::
+
+   This file is for illustration. It references fixtures that would
+   normally be in conftest.py.
+
+"""
+import pytest
+
+
+# 1. Basic fixture
+@pytest.fixture
+def db():
+    connection = {"connected": True, "data": {}}
+    yield connection
+    connection["connected"] = False
+
+
+# 2. Fixture with scope
+@pytest.fixture(scope="module")
+def app():
+    application = {"started": True}
+    yield application
+    application["started"] = False
+
+
+# 3. Autouse fixture
+@pytest.fixture(autouse=True)
+def clean_state():
+    yield
+    # cleanup after each test
+
+
+# 4. Fixture using another fixture
+@pytest.fixture
+def admin_user(db):
+    user = {"name": "admin"}
+    db["data"]["admin"] = user
+    yield user
+
+
+# 5. Test using fixtures via argument injection
+def test_query(db):
+    db["data"]["key"] = "value"
+    assert db["data"]["key"] == "value"
+
+
+def test_admin(admin_user, db):
+    assert db["data"]["admin"] == admin_user
+
+
+# 6. Class-based test
+class TestApp:
+    def test_started(self, app):
+        assert app["started"] is True


### PR DESCRIPTION
This change adds documentation:

* `README.md` becomes an overview, with links to documentation for specific needs.
* A tutorial to teach the reader how to use pytest-unmagic.
* A complete reference.
* An FAQ to deal with errors and questions.
* The principles behind pytest-unmagic.
* Examples for migrating from pytest fixtures to pytest-unmagic.
* How-to guides for specific features.
