### PR TITLE
Modify README.md, add Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,217 +2,216 @@
 
 Pytest fixtures with conventional import semantics.
 
+pytest-unmagic removes the "magic" from pytest fixtures. Instead of
+relying on argument-name matching, fixtures are explicitly imported and
+applied using standard Python conventions. This gives you IDE
+navigation, clear dependency chains, and `unittest.TestCase` support.
+
+## Quick Comparison
+
+**Standard pytest** (implicit):
+
+conftest.py
+```python
+import pytest
+
+@pytest.fixture
+def db():
+    return create_database()
+```
+
+test_app.py -- where does `db` come from?
+```python
+def test_query(db):
+    assert db.query("SELECT 1")
+```
+
+**pytest-unmagic** (explicit):
+
+fixtures.py
+```python
+from unmagic import fixture
+
+@fixture
+def db():
+    yield create_database()
+```
+
+test_app.py -- clear import, visible dependency
+```python
+from fixtures import db
+
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
 ## Installation
 
 ```sh
 pip install pytest-unmagic
 ```
 
-## Usage
+## Quick Start
 
-Define fixtures with the `unmagic.fixture` decorator, and apply them to other
-fixtures or test functions with `unmagic.use`.
+Define a fixture with `@fixture`, apply it with `@use` or call it to get
+its value:
 
-```py
+```python
 from unmagic import fixture, use
 
-traces = []
+@fixture
+def greeting():
+    yield "hello"
+
+@use(greeting)
+def test_greeting():
+    value = greeting()
+    assert value == "hello"
+```
+
+## Key Features
+
+- **Explicit imports:** Fixtures are regular Python objects, imported
+  where used
+
+- **IDE support:** go-to-definition, find-usages, and refactoring work
+  out of the box
+
+- **`unittest.TestCase` support:** Apply fixtures to TestCase classes
+  with `@use`
+
+- **Gradual adoption:** Mix with standard pytest fixtures, migrate
+  incrementally
+
+- **Fixture scopes:** `function`, `class`, `module`, `package`, `session`
+
+- **Magic fence:** Warn when magic fixtures are used in designated
+  modules
+
+## Core Concepts
+
+### Define a fixture
+
+```python
+from unmagic import fixture
 
 @fixture
-def tracer():
-    assert not traces, f"unexpected traces before setup: {traces}"
-    yield
-    traces.clear()
-
-@use(tracer)
-def test_append():
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+def db():
+    connection = create_connection()
+    yield connection
+    connection.close()
 ```
 
-A fixture must yield exactly once. The `@use` decorator causes the fixture to be
-set up and registered for tear down, but does not pass the yielded value to the
-decorated function. This is appropriate for fixtures that have side effects.
+The fixture must yield exactly once. Code before `yield` is setup; code
+after is teardown.
 
-The location where a fixture is defined has no affect on where it can be used.
-Any code that can import it can use it as long as it is executed in the context
-of running tests and does not violate scope restrictions.
+### Apply a fixture with `@use`
 
-### @use shorthand
+```python
+from unmagic import use
 
-If a single fixture is being applied to another fixture or test it may be
-applied directly as a decorator without `@use()`. The test in the example above
-could have been written as
-
-```py
-@tracer
-def test_append():
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+@use(db)
+def test_insert():
+    database = db()
+    database.insert({"key": "value"})
 ```
 
-### Applying fixtures to test classes
+`@use` sets up the fixture and registers it for teardown. Call the fixture to retrieve its value.
 
-The `@use` decorator can be used on test classes, which applies the fixture(s)
-to every test in the class.
+### `@use` shorthand
 
-```py
-@use(tracer)
-class TestClass:
-    def test_galaxy(self):
-        traces.append("Is anybody out there?")
-```
+A single fixture can be applied directly as a decorator:
 
-#### Unmagic fixtures on `unittest.TestCase` tests
-
-Unlike standard pytest fixtures, unmagic fixtures can be applied directly to
-`unittest.TestCase` tests.
-
-### Call a fixture to retrieve its value
-
-The value of a fixture can be retrieved within a test function or other fixture
-by calling the fixture. This is similar to `request.getfixturevalue()`.
-
-```py
-@fixture
-def tracer():
-    assert not traces, f"unexpected traces before setup: {traces}"
-    yield traces
-    traces.clear()
-
-def test_append():
-    traces = tracer()
-    traces.append("hello")
-    assert traces, "expected at least one trace"
+```python
+@db
+def test_insert():
+    database = db()
+    ...
 ```
 
 ### Fixture scope
 
-Fixtures may declare a `scope` of `'function'` (the default), `'class'`,
-`'module'`, `'package'`, or `'session'`. A fixture will be torn down after all
-tests in its scope have run if any in-scope tests used the fixture.
-
-```py
-@fixture(scope="class")
-def tracer():
-    traces = []
-    yield traces
-    assert traces, "expected at least one trace"
+```python
+@fixture(scope="module")
+def shared_db():
+    yield create_database()
 ```
+
+### Apply fixtures to classes
+
+```python
+@use(db)
+class TestQueries:
+    def test_select(self):
+        database = db()
+        assert database.query("SELECT 1")
+```
+
+Works with `unittest.TestCase` too, unlike standard pytest fixtures.
 
 ### Autouse fixtures
 
-Fixtures may be applied to tests automatically with `@fixture(autouse=...)`. The
-value of the `autouse` parameter may be one of
-
-- A test module or package path (usually `__file__`) to apply the fixture to all
-  tests within the module or package.
-- `True`: apply the fixture to all tests in the session.
-
-A single fixture may be registered for autouse in multiple modules and packages
-with ``unmagic.autouse``.
-
-```py
-# tests/fixtures.py
-from unmagic import fixture
-
-@fixture
-def a_fixture():
-    ...
-
-
-# tests/test_this.py
-from unmagic import autouse
-from .fixtures import a_fixture
-
-autouse(a_fixture, __file__)
-
-...
-
-
-# tests/test_that.py
-from unmagic import autouse
-from .fixtures import a_fixture
-
-autouse(a_fixture, __file__)
-
-...
+```python
+@fixture(autouse=__file__)
+def setup_env():
+    os.environ["MODE"] = "test"
+    yield
+    del os.environ["MODE"]
 ```
 
-### Magic fixture fence
+Or register autouse from another module:
 
-It is possible to errect a fence around tests in a particular module or package
-to ensure that magic fixtures are not used in that namespace except with the
-`@use(...)` decorator.
+```python
+from unmagic import autouse
+from .fixtures import setup_env
 
-```py
-from unmagic import fence
-
-fence.install(['mypackage.tests'])
+autouse(setup_env, __file__)
 ```
 
-This will cause warnings to be emitted for magic fixture usages within
-`mypackage.tests`.
+### Access pytest fixtures
 
-
-### Accessing the pytest request object
-
-The `unmagic.get_request()` function provides access to the test request object.
-Among other things, it can be used to retrieve fixtures defined with
-`@pytest.fixture`.
-
-```py
+```python
 from unmagic import get_request
 
 def test_output():
     capsys = get_request().getfixturevalue("capsys")
     print("hello")
-    captured = capsys.readouterr()
-    assert captured.out == "hello\n"
+    assert capsys.readouterr().out == "hello\n"
 ```
 
-### `@use` pytest fixtures
-
-Fixtures defined with `@pytest.fixture` can be applied to a test or other
-fixture by passing the fixture name to `@use`. None of the built-in fixtures
-provided by pytest make sense to use this way, but it is a useful technique for
-fixtures that have side effects, such as pytest-django's `db` fixture.
-
-```py
-from unmagic import use
-
-@use("db")
-def test_database():
-    ...
-```
-
-### Chaining fixtures
-
-Fixtures that use other fixtures should be decorated with `@use`, so
-that fixture dependencies are chained.
+Or apply pytest fixtures by name:
 
 ```python
-@use("db")
-def parent_fixture():
-    daedalus = Person.objects.create(name='Daedalus')
-    yield daedalus
-    daedalus.delete()
+from unmagic import use
 
-@use(parent_fixture)
-@fixture
-def child_fixture():
-    daedalus = parent_fixture()
-    icarus = Person.objects.create(name='Icarus', father=daedalus)
-    yield
-
-@use(child_fixture)
-def test_flight():
-    flyers = Person.objects.all()
+@use("db")  # pytest-django's db fixture
+def test_models():
     ...
 ```
 
+### Magic fixture fence
 
-## Running the `unmagic` test suite
+Warn when magic fixtures are used in specified modules:
+
+```python
+from unmagic import fence
+
+fence.install(["mypackage.tests"])
+```
+
+## Documentation
+
+| Document                                   | Description                           |
+|--------------------------------------------|---------------------------------------|
+| [API Reference](docs/api-reference.md)     | Complete technical reference          |
+
+## Compatibility
+
+- **Python:** 3.9+
+- **pytest:** 8.1+
+
+## Running the Test Suite
 
 ```sh
 cd path/to/pytest-unmagic
@@ -220,13 +219,12 @@ pip install -e .
 pytest
 ```
 
+## Publishing
 
-## Publishing a new verison to PyPI
+Push a tag matching `vX.Y.Z` (where X.Y.Z matches the version in
+[`__init__.py`](src/unmagic/__init__.py)) to publish to PyPI.
 
-Push a new tag to Github using the format vX.Y.Z where X.Y.Z matches the version
-in [`__init__.py`](src/unmagic/__init__.py).
-
-A new version is published to https://test.pypi.org/p/pytest-unmagic on every
+A test release is published to https://test.pypi.org/p/pytest-unmagic on every
 push to the *main* branch.
 
-Publishing is automated with [Github Actions](.github/workflows/pypi.yml).
+Publishing is automated with [GitHub Actions](.github/workflows/pypi.yml).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,373 @@
+# API Reference
+
+Complete technical reference for all public APIs in pytest-unmagic.
+
+## Module: `unmagic`
+
+### `fixture(func=None, /, scope="function", autouse=False)`
+
+Define an unmagic fixture.
+
+**Parameters:**
+
+| Parameter | Type              | Default      | Description                                                                                                                                      |
+|-----------|-------------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `func`    | callable or `str` | `None`       | A generator function, context manager, or pytest fixture name (string). When `None`, returns a decorator.                                        |
+| `scope`   | `str`             | `"function"` | Fixture lifecycle scope. One of: `"function"`, `"class"`, `"module"`, `"package"`, `"session"`.                                                  |
+| `autouse` | `bool` or `str`   | `False`      | Automatically apply the fixture. `True` applies to all tests. A file path (typically `__file__`) applies to tests within that module or package. |
+
+**Returns:** `UnmagicFixture` instance.
+
+**Usage as decorator:**
+
+```python
+from unmagic import fixture
+
+@fixture
+def my_fixture():
+    # setup
+    value = create_resource()
+    yield value
+    # teardown
+    cleanup_resource(value)
+```
+
+**Usage with scope:**
+
+```python
+@fixture(scope="module")
+def shared_resource():
+    yield create_expensive_resource()
+```
+
+**Usage with autouse:**
+
+```python
+# Apply to all tests in this module
+@fixture(autouse=__file__)
+def setup_env():
+    yield
+
+# Apply to all tests in the session
+@fixture(autouse=True)
+def global_setup():
+    yield
+```
+
+**Usage with a context manager:**
+
+```python
+from unittest.mock import patch
+
+fixture(patch("mymodule.func", return_value=42), autouse=__file__)
+```
+
+**Usage with a string (pytest fixture name):**
+
+```python
+db = fixture("db")  # Wraps pytest-django's db fixture
+```
+
+**Requirements:**
+
+- Generator functions must yield exactly once
+- The yielded value becomes the fixture's return value when called
+- Code after `yield` runs during teardown
+- String arguments cannot use `autouse` or non-default `scope`
+
+---
+
+### `use(*fixtures)`
+
+Apply one or more fixtures to a test function, test class, or another fixture.
+
+**Parameters:**
+
+| Parameter   | Type                                        | Description                                                                     |
+|-------------|---------------------------------------------|---------------------------------------------------------------------------------|
+| `*fixtures` | `UnmagicFixture`, context manager, or `str` | One or more fixtures to apply. Strings are interpreted as pytest fixture names. |
+
+**Returns:** Decorator function.
+
+**Raises:** `TypeError` if no fixtures are provided.
+
+**Apply to a test function:**
+
+```python
+from unmagic import fixture, use
+
+@fixture
+def db():
+    yield create_db()
+
+@use(db)
+def test_query():
+    database = db()
+    assert database.query("SELECT 1")
+```
+
+**Apply to a test class:**
+
+```python
+@use(db)
+class TestDatabase:
+    def test_insert(self):
+        database = db()
+        database.insert({"key": "value"})
+
+    def test_query(self):
+        database = db()
+        assert database.query("SELECT 1")
+```
+
+**Apply multiple fixtures:**
+
+```python
+@use(db, cache, auth)
+def test_full_stack():
+    ...
+```
+
+**Apply a pytest fixture by name:**
+
+```python
+@use("db")
+def test_django():
+    ...
+```
+
+**Chain fixture dependencies:**
+
+```python
+@use(db)
+@fixture
+def populated_db():
+    database = db()
+    database.insert(seed_data)
+    yield database
+```
+
+> [!NOTE]
+> When applying `@use` to a fixture, place `@use` *above* `@fixture`:
+
+```python
+# Correct order:
+@use(dependency)
+@fixture
+def my_fixture():
+    yield
+
+# Wrong: @use cannot wrap an autouse fixture:
+@use(dependency)
+@fixture(autouse=__file__)  # TypeError
+def my_fixture():
+    yield
+
+# Correct: apply @use before @fixture(autouse=...):
+@fixture(autouse=__file__)
+@use(dependency)
+def my_fixture():
+    yield
+```
+
+---
+
+### `get_request()`
+
+Get the active pytest request object.
+
+**Returns:** `pytest.FixtureRequest`
+
+**Raises:** `ValueError` if called outside of a test or fixture context (i.e., there is no active request).
+
+**Access pytest fixtures:**
+
+```python
+from unmagic import get_request
+
+def test_output():
+    capsys = get_request().getfixturevalue("capsys")
+    print("hello")
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+```
+
+**Access test metadata:**
+
+```python
+def test_node_info():
+    request = get_request()
+    print(request.node.name)      # test name
+    print(request.node.nodeid)    # full test ID
+```
+
+---
+
+### `autouse(fixture, where)`
+
+Register a fixture for automatic use within a scope.
+
+This is useful when the fixture is defined in a shared module and you want to apply it to specific test modules or packages without using `@fixture(autouse=...)`.
+
+**Parameters:**
+
+| Parameter | Type             | Description                                                                             |
+|-----------|------------------|-----------------------------------------------------------------------------------------|
+| `fixture` | `UnmagicFixture` | An unmagic fixture to register.                                                         |
+| `where`   | `str` or `True`  | `__file__` to apply within the current module or package. `True` to apply to all tests. |
+
+**Returns:** None.
+
+**Apply to a specific module:**
+
+```python
+# tests/fixtures.py
+from unmagic import fixture
+
+@fixture
+def setup_env():
+    yield
+
+# tests/test_this.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+```
+
+**Apply to a package (in `__init__.py`):**
+
+```python
+# tests/__init__.py
+from unmagic import autouse
+from .fixtures import setup_env
+
+autouse(setup_env, __file__)
+```
+
+When `__file__` is in an `__init__.py`, the fixture applies to the entire package.
+
+**Apply globally:**
+
+```python
+autouse(setup_env, True)
+```
+
+> [!WARNING]
+> Calling `autouse()` during test execution (after collection) will emit
+> a `UserWarning` since relevant tests may have already run.
+
+---
+
+## Module: `unmagic.fence`
+
+### `fence.install(names=(), reset=False)`
+
+Install a fence that warns when magic fixtures are used within the named
+modules or packages.
+
+**Parameters:**
+
+| Parameter | Type              | Default | Description                                                       |
+|-----------|-------------------|---------|-------------------------------------------------------------------|
+| `names`   | sequence of `str` | `()`    | Module or package names to fence.                                 |
+| `reset`   | `bool`            | `False` | If `True`, replace all existing fences instead of adding to them. |
+
+**Returns:** Context manager. The fence is removed when the context exits.
+
+**Raises:** `ValueError` if `names` is a string instead of a sequence.
+
+**Install globally (e.g., in `conftest.py`):**
+
+```python
+# conftest.py
+from unmagic import fence
+
+fence.install(["mypackage.tests"])
+```
+
+**Install as a context manager:**
+
+```python
+from unmagic import fence
+
+with fence.install(["mypackage.tests"]):
+    # fence is active
+    ...
+# fence is removed
+```
+
+**Install for a pytest session with a fixture:**
+
+```python
+from pytest import fixture
+from unmagic import fence
+
+@fixture(scope="session", autouse=True)
+def enforce_unmagic():
+    with fence.install(["tests"]):
+        yield
+```
+
+**Nested fences:**
+
+Fences stack. Each `fence.install()` adds to the set of fenced modules.
+Inner fences are removed when their context exits, but outer fences
+remain.
+
+---
+
+### `fence.is_fenced(func)`
+
+Check whether a function is within a fenced module.
+
+**Parameters:**
+
+| Parameter | Type     | Description                                                          |
+|-----------|----------|----------------------------------------------------------------------|
+| `func`    | callable | A function to check. Uses `func.__module__` to determine membership. |
+
+**Returns:** `bool` -- `True` if the function's module is within a fenced namespace.
+
+```python
+from unmagic import fence
+
+with fence.install(["mypackage.tests"]):
+    from mypackage.tests.test_example import some_func
+    assert fence.is_fenced(some_func)
+```
+
+---
+
+## Fixture Calling Convention
+
+An `UnmagicFixture` instance is callable with two behaviors:
+
+- **`fixture()`** (no arguments): Retrieves the fixture's yielded value.
+  The fixture is set up if it hasn't been already. Must be called
+  within a test or fixture context.
+
+- **`fixture(func)`** (one argument): Applies the fixture to `func`,
+  equivalent to `@use(fixture)`. This is the `@use` shorthand.
+
+```python
+@fixture
+def db():
+    yield create_database()
+
+# Shorthand: apply as decorator
+@db
+def test_something():
+    database = db()  # retrieve value
+    ...
+```
+
+---
+
+## Compatibility
+
+|                       | Supported                   |
+|-----------------------|-----------------------------|
+| **Python**            | 3.9, 3.10, 3.11, 3.12, 3.13 |
+| **pytest**            | 8.1, 8.2, 8.3, 8.4          |
+| **unittest.TestCase** | Yes (via `@use` on class)   |


### PR DESCRIPTION
This is the first of a series of PRs that break up PR https://github.com/dimagi/pytest-unmagic/pull/5.

This branch turns `README.md` into a high-level overview of the library, and adds the API Reference.
