### PR TITLE
Ensure that pytest-django sets up DB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         python --version
         pip install --upgrade pip flake8
         pip install pytest~=${{ matrix.pytest }}.0
-        pip install -e .
+        pip install -e .[test]
     - name: Run tests
       run: pytest
     - name: Check style

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
         pytest: ['8.1', '8.2', '8.3', '8.4']
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "pytest",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest-django>=4.12",
+    "django>=4.2,<6",
+]
 
 [project.entry-points.pytest11]
 unmagic = "unmagic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,17 @@ authors = [{name = "Daniel Miller", email = "millerdev@gmail.com"}]
 license = {file = "LICENSE"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dynamic = ["version", "description"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Testing",
 ]

--- a/src/unmagic/_django.py
+++ b/src/unmagic/_django.py
@@ -45,3 +45,61 @@ def _is_pytest_fixture_id(fid):
     # intentionally not what pytest-django looks for. `type(x) is str`
     # — not `isinstance` — is the discriminator.
     return type(fid) is str
+
+
+# pytest-django fixture names whose resolution implies the test DB
+# must already be set up for the session. These are the names
+# pytest-django itself checks for at collection time (see
+# pytest_django/plugin.py::_get_databases_for_test).
+_DB_FIXTURE_NAMES = frozenset({
+    "db",
+    "transactional_db",
+    "django_db_reset_sequences",
+    "django_db_serialized_rollback",
+    "live_server",
+})
+
+
+def guard_pytest_fixture_access(name, request):
+    """Raise if a pytest-django DB fixture is resolved without
+    declaration.
+
+    Called from `PytestFixture._get_value` before delegating to
+    `request.getfixturevalue`. If pytest-django is not loaded, or
+    the fixture is not one of the DB-triggering ones, this is a
+    no-op.
+
+    The signal that DB setup was planned: either the name is in the
+    test item's `fixturenames` (which `inject_fixturenames` arranges
+    for any @use'd DB fixture), or the item carries a `django_db`
+    marker. Absence of both means pytest-django did not invoke
+    `setup_databases()` and using the fixture would either error
+    inside pytest-django's blocker or fall through to the dev DB.
+
+    Limitations:
+    - This guard assumes ``request.node`` is the test item. For the
+      `@use(...)` flow that is always the case, but if a future caller
+      resolves ``PytestFixture`` from a non-test request, ``fixturenames``
+      and ``get_closest_marker`` may not reflect the test's collection-time
+      state.
+    - Multi-database setups (``@pytest.mark.django_db(databases=[...])``)
+      are not introspected. A ``django_db`` marker on the item, regardless
+      of its ``databases`` list, is treated as evidence that DB setup was
+      planned.
+    """
+    if name not in _DB_FIXTURE_NAMES:
+        return
+    if not is_pytest_django_loaded(request.config):
+        return
+    node = request.node
+    if name in node.fixturenames:
+        return
+    if node.get_closest_marker("django_db") is not None:
+        return
+    raise RuntimeError(
+        f"pytest-django fixture {name!r} was resolved, but "
+        f"pytest-django did not set up the test database for this "
+        f"session. Declare the dependency with @use({name!r}) on "
+        f"the test or on a fixture in its @use chain, or apply "
+        f"@pytest.mark.django_db to the test."
+    )

--- a/src/unmagic/_django.py
+++ b/src/unmagic/_django.py
@@ -13,3 +13,35 @@ _PYTEST_DJANGO_PLUGIN_NAME = "django"
 def is_pytest_django_loaded(config):
     """Return True if pytest-django is registered with the pytest config."""
     return config.pluginmanager.hasplugin(_PYTEST_DJANGO_PLUGIN_NAME)
+
+
+def inject_fixturenames(item, fixtures):
+    """Surface @use'd pytest-fixture names on the test item.
+
+    pytest-django decides at collection time whether to set up the
+    test database by scanning each item's `fixturenames` (and
+    django_db markers). Because unmagic resolves @use'd fixtures
+    lazily via `getfixturevalue`, those names are absent from
+    `fixturenames` at collection time.
+
+    For every pytest-fixture name in the transitive @use graph of
+    `fixtures`, append it to `item.fixturenames` if not already
+    present. Unmagic-native fixtures (whose `_id` is a `_UnmagicID`,
+    not a plain str) are skipped — pytest-django does not look for
+    those names.
+    """
+    if not is_pytest_django_loaded(item.config):
+        return
+    names = item.fixturenames
+    for fix in fixtures:
+        fid = getattr(fix, "_id", None)
+        if _is_pytest_fixture_id(fid) and fid not in names:
+            names.append(fid)
+
+
+def _is_pytest_fixture_id(fid):
+    # PytestFixture stores a plain str as _id; UnmagicFixture stores a
+    # _UnmagicID (str subclass with identity equality) which is
+    # intentionally not what pytest-django looks for. `type(x) is str`
+    # — not `isinstance` — is the discriminator.
+    return type(fid) is str

--- a/src/unmagic/_django.py
+++ b/src/unmagic/_django.py
@@ -1,0 +1,15 @@
+"""pytest-django interop for unmagic fixtures.
+
+This module is a no-op when pytest-django is not installed or not
+loaded. It is imported unconditionally by `unmagic.fixtures`; all
+behavior is gated on `is_pytest_django_loaded(config)`.
+"""
+
+# Name registered by pytest-django's pytest11 entry point
+# (`pytest11 = django = pytest_django.plugin`).
+_PYTEST_DJANGO_PLUGIN_NAME = "django"
+
+
+def is_pytest_django_loaded(config):
+    """Return True if pytest-django is registered with the pytest config."""
+    return config.pluginmanager.hasplugin(_PYTEST_DJANGO_PLUGIN_NAME)

--- a/src/unmagic/fixtures.py
+++ b/src/unmagic/fixtures.py
@@ -223,7 +223,9 @@ class PytestFixture(UnmagicFixture):
         super().__init__(func, None, None)
 
     def _get_value(self):
-        return get_request().getfixturevalue(self._id)
+        request = get_request()
+        _django.guard_pytest_fixture_access(self._id, request)
+        return request.getfixturevalue(self._id)
 
     def _is_registered_for(self, node):
         return True

--- a/src/unmagic/fixtures.py
+++ b/src/unmagic/fixtures.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import pytest
 
-from . import _api
+from . import _api, _django
 from .autouse import autouse as _autouse
 from .scope import get_request
 
@@ -288,3 +288,4 @@ def pytest_itemcollected(item):
         for fixture in fixtures:
             if not fixture._is_registered_for(item):
                 fixture._register(item)
+        _django.inject_fixturenames(item, fixtures)

--- a/tests/django_app/models.py
+++ b/tests/django_app/models.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class Thing(models.Model):
+    name = models.CharField(max_length=64)
+
+    class Meta:
+        app_label = "django_app"

--- a/tests/django_app/settings.py
+++ b/tests/django_app/settings.py
@@ -1,0 +1,9 @@
+SECRET_KEY = "unmagic-test"
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
+}
+INSTALLED_APPS = ["tests.django_app"]
+USE_TZ = True

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -3,12 +3,70 @@
 Each test drives a sub-pytest via `pytester` with `pytest-django` loaded
 and `DJANGO_SETTINGS_MODULE` pointing at `tests.django_app.settings`.
 """
+import textwrap
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from unmagic import _django
+import _pytest.pytester as _pytester
+
+from unmagic import _django, fixture, use
+from unmagic.scope import get_request
+
+from .util import unmagic_inactive
+
+
+@fixture
+def django_tester():
+    with patch.object(_pytester, "main", unmagic_inactive()(_pytester.main)):
+        pytester = get_request().getfixturevalue("pytester")
+        pytester.makeini(textwrap.dedent("""
+            [pytest]
+            DJANGO_SETTINGS_MODULE = tests.django_app.settings
+        """))
+        yield pytester
 
 
 def test_bridge_is_inert_when_pytest_django_not_loaded():
     pm = SimpleNamespace(hasplugin=lambda _: False)
     config = SimpleNamespace(pluginmanager=pm)
     assert _django.is_pytest_django_loaded(config) is False
+
+
+@use(django_tester)
+def test_use_db_triggers_pytest_django_setup():
+    tester = django_tester()
+    tester.makepyfile(textwrap.dedent("""
+        from unmagic import use
+        from tests.django_app.models import Thing
+
+        @use('db')
+        def test_creates_row():
+            Thing.objects.create(name='x')
+            assert Thing.objects.count() == 1
+    """))
+    result = tester.runpytest("-q")
+    result.assert_outcomes(passed=1)
+
+
+@use(django_tester)
+def test_use_db_via_nested_unmagic_fixture():
+    """A user-defined unmagic fixture that declares @use('db') in its
+    own decorator chain should still trigger DB setup when applied to
+    a test that does not itself declare 'db'."""
+    tester = django_tester()
+    tester.makepyfile(textwrap.dedent("""
+        from unmagic import fixture, use
+        from tests.django_app.models import Thing
+
+        @use('db')
+        @fixture
+        def seeded():
+            Thing.objects.create(name='seed')
+            yield
+
+        @use(seeded)
+        def test_reads_seed():
+            assert Thing.objects.filter(name='seed').exists()
+    """))
+    result = tester.runpytest("-q")
+    result.assert_outcomes(passed=1)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -134,3 +134,26 @@ def test_declared_db_does_not_trip_runtime_guard():
     """))
     result = tester.runpytest("-q")
     result.assert_outcomes(passed=1)
+
+
+def test_no_django_means_no_injection_and_no_guard():
+    """Run a sub-pytest with pytest-django disabled. A test using
+    @use('some_pytest_fixture') should still work; the unmagic bridge
+    must not interfere when pytest-django is absent."""
+    with patch.object(_pytester, "main", unmagic_inactive()(_pytester.main)):
+        request = get_request()
+        pytester = request.getfixturevalue("pytester")
+        pytester.makepyfile(textwrap.dedent("""
+            import pytest
+            from unmagic import use
+
+            @pytest.fixture
+            def greeting():
+                return 'hi'
+
+            @use('greeting')
+            def test_greeting():
+                pass
+        """))
+        result = pytester.runpytest("-q", "-p", "no:django")
+        result.assert_outcomes(passed=1)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,14 @@
+"""Integration tests for the pytest-django bridge.
+
+Each test drives a sub-pytest via `pytester` with `pytest-django` loaded
+and `DJANGO_SETTINGS_MODULE` pointing at `tests.django_app.settings`.
+"""
+from types import SimpleNamespace
+
+from unmagic import _django
+
+
+def test_bridge_is_inert_when_pytest_django_not_loaded():
+    pm = SimpleNamespace(hasplugin=lambda _: False)
+    config = SimpleNamespace(pluginmanager=pm)
+    assert _django.is_pytest_django_loaded(config) is False

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -70,3 +70,67 @@ def test_use_db_via_nested_unmagic_fixture():
     """))
     result = tester.runpytest("-q")
     result.assert_outcomes(passed=1)
+
+
+@use(django_tester)
+def test_inline_db_call_without_declaration_raises():
+    """A fixture body that resolves the pytest-django `db` fixture
+    inline (via `db()`) without it being declared anywhere up the
+    chain must raise a clear error, not silently hit the dev DB.
+
+    The stdout-based assertions below (and the negative
+    `no_fnmatch_line` checks) are load-bearing: pytest surfaces
+    setup-time failures differently across versions, so checking
+    outcome counters is too brittle here. The assertions instead
+    prove the error type, the fixture name, the message, and that
+    neither the stealth fixture body nor the test body executed.
+    """
+    tester = django_tester()
+    tester.makepyfile(textwrap.dedent("""
+        from unmagic import fixture, use
+        from unmagic.fixtures import UnmagicFixture
+        from tests.django_app.models import Thing
+
+        # Resolve the pytest-django 'db' fixture from inside the body.
+        db = UnmagicFixture.create('db')
+
+        @fixture
+        def stealth_db():
+            db()  # inline resolution; never declared via @use
+            print("STEALTH_DB_RAN")  # must not appear in output
+            yield
+
+        @use(stealth_db)
+        def test_inline():
+            print("TEST_BODY_RAN")  # must not appear in output
+            Thing.objects.create(name='x')
+    """))
+    result = tester.runpytest("-q")
+    # Pytest surfaces setup-time failures differently across versions,
+    # so assert on stdout rather than the outcome counters.
+    assert result.ret != 0
+    result.stdout.fnmatch_lines([
+        "*RuntimeError*",
+        "*pytest-django fixture 'db'*",
+        "*pytest-django did not set up the test database*",
+    ])
+    result.stdout.no_fnmatch_line("*STEALTH_DB_RAN*")
+    result.stdout.no_fnmatch_line("*TEST_BODY_RAN*")
+
+
+@use(django_tester)
+def test_declared_db_does_not_trip_runtime_guard():
+    """When 'db' is declared via @use, the runtime guard must let
+    the fixture resolve normally."""
+    tester = django_tester()
+    tester.makepyfile(textwrap.dedent("""
+        from unmagic import use
+        from tests.django_app.models import Thing
+
+        @use('db')
+        def test_ok():
+            Thing.objects.create(name='ok')
+            assert Thing.objects.count() == 1
+    """))
+    result = tester.runpytest("-q")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
This branch ensures that pytest-django sets up the test DB when tests using only pytest-unmagic fixtures need it.

It does this by injecting pytest-unmagic fixture names at collection time.

It also raises an error at runtime if a test uses a database fixture inline without the `@use` decorator (and so bypassing detection at collection time).

Ping @millerdev 