### PR TITLE
Ignore modules not in a package with `names=['']`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -322,7 +322,7 @@ or packages.
 
 | Parameter | Type              | Default | Description                                                       |
 |-----------|-------------------|---------|-------------------------------------------------------------------|
-| `names`   | sequence of `str` | `()`    | Module or package names to fence.                                 |
+| `names`   | sequence of `str` | `()`    | Module or package names to fence. An empty string (`''`) matches modules that are not in a package. |
 | `reset`   | `bool`            | `False` | If `True`, replace all existing fences instead of adding to them. |
 
 **Returns:** a context manager. The fence is removed when the context exits.

--- a/src/unmagic/fence.py
+++ b/src/unmagic/fence.py
@@ -12,6 +12,10 @@ def install(names=(), reset=False):
 
     Warn if pytest magic fixtures are used within the named
     modules/packages.
+
+    :param names: A sequence of package names. An empty string
+    matches modules that are not in a package.
+    :param reset: Reset the fence, ignoring previously fenced names.
     """
     if isinstance(names, str):
         raise ValueError("names should be a sequence of strings, not a string")
@@ -62,6 +66,8 @@ def _uninstall(fence):
 def is_fenced(func):
     fence = _fences[-1]
     mod = func.__module__
+    if "." not in mod and '' in fence:
+        return True
     while mod not in fence:
         if "." not in mod or not fence:
             return False

--- a/tests/test_fence.py
+++ b/tests/test_fence.py
@@ -36,6 +36,17 @@ def test_new_fence_does_not_remove_previously_installed_fence():
     assert not fence.is_fenced(func)
 
 
+def test_module_with_no_package_is_fenced():
+    def func():
+        ...
+
+    func.__module__ = "test_something"
+
+    with fence.install(['']):
+        assert fence.is_fenced(func)
+    assert not fence.is_fenced(func)
+
+
 def func():
     ...
 


### PR DESCRIPTION
`pytest` discovers tests in directories that lack `__init__.py`. Because those modules don't belong to any package, there was previously no way to exclude them as a group.