### PR TITLE
Prepare for version 1.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   configure:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Read Python versions from pyproject.toml
       id: read-versions
       # produces output like: python_versions=[ "3.10", "3.11", "3.12", "3.13", "3.14" ]
@@ -33,7 +33,7 @@ jobs:
         python: ${{ fromJSON(needs.configure.outputs.python_versions) }}
         pytest: ['8.1', '8.2', '8.3', '8.4', '9.0']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: astral-sh/setup-uv@v7
       with:
         version: '>=0.7'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  configure:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Read Python versions from pyproject.toml
+      id: read-versions
+      # produces output like: python_versions=[ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+      run: >-
+        echo "python_versions=$(
+        grep -oP '(?<=Language :: Python :: )\d\.\d+' pyproject.toml
+        | jq --raw-input .
+        | jq --slurp .
+        | tr '\n' ' '
+        )" >> $GITHUB_OUTPUT
+    outputs:
+      python_versions: ${{ steps.read-versions.outputs.python_versions }}
+
   tests:
+    needs: [configure]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        pytest: ['8.1', '8.2', '8.3', '8.4']
+        python: ${{ fromJSON(needs.configure.outputs.python_versions) }}
+        pytest: ['8.1', '8.2', '8.3', '8.4', '9.0']
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,16 +34,15 @@ jobs:
         pytest: ['8.1', '8.2', '8.3', '8.4', '9.0']
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v7
       with:
+        version: '>=0.7'
         python-version: ${{ matrix.python }}
     - name: Setup
       run: |
-        python --version
-        pip install --upgrade pip flake8
-        pip install pytest~=${{ matrix.pytest }}.0
-        pip install -e .
+        uv venv --python=${{ matrix.python }}
+        uv pip install flake8 pytest~=${{ matrix.pytest }}.0 --editable .
     - name: Run tests
-      run: pytest
+      run: .venv/bin/pytest
     - name: Check style
-      run: flake8 src/unmagic/ tests/
+      run: .venv/bin/flake8 src/unmagic/ tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0 - 2026-06-04
+
+- Simplify `README.md` and add `docs/reference.md` and `CONTRIBUTING.md`.
+- Allow modules that are not in a package to be fenced with an empty string.
+- Drop support for Python 3.9 (EOL).
+
 # 1.0.1 - 2025-07-22
 
 - Add support for pytest 8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,17 @@ authors = [{name = "Daniel Miller", email = "millerdev@gmail.com"}]
 license = {file = "LICENSE"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dynamic = ["version", "description"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Testing",
 ]

--- a/src/unmagic/__init__.py
+++ b/src/unmagic/__init__.py
@@ -7,7 +7,7 @@ from .autouse import autouse
 from .fixtures import fixture, use
 from .scope import get_request
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __all__ = ["autouse", "fixture", "get_request", "use"]
 
 pytest_plugins = ["unmagic.fence", "unmagic.fixtures", "unmagic.scope"]


### PR DESCRIPTION
### New in v1.1.0

- Simplify `README.md` and add `docs/reference.md` and `CONTRIBUTING.md`.
- Allow modules that are not in a package to be fenced with an empty string.
- Drop support for Python 3.9 (EOL).
